### PR TITLE
adjust meta.yml and boilerplate after move to coq-community

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,21 @@ Follow the instructions on https://github.com/coq-community/templates to regener
 # CoqEAL
 
 [![Docker CI][docker-action-shield]][docker-action-link]
+[![Contributing][contributing-shield]][contributing-link]
+[![Code of Conduct][conduct-shield]][conduct-link]
+[![Zulip][zulip-shield]][zulip-link]
 
-[docker-action-shield]: https://github.com/CoqEAL/coqeal/workflows/Docker%20CI/badge.svg?branch=master
-[docker-action-link]: https://github.com/CoqEAL/coqeal/actions?query=workflow:"Docker%20CI"
+[docker-action-shield]: https://github.com/coq-community/CoqEAL/workflows/Docker%20CI/badge.svg?branch=master
+[docker-action-link]: https://github.com/coq-community/CoqEAL/actions?query=workflow:"Docker%20CI"
 
+[contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
+[contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md
+
+[conduct-shield]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-%23f15a24.svg
+[conduct-link]: https://github.com/coq-community/manifesto/blob/master/CODE_OF_CONDUCT.md
+
+[zulip-shield]: https://img.shields.io/badge/chat-on%20zulip-%23c1272d.svg
+[zulip-link]: https://coq.zulipchat.com/#narrow/stream/237663-coq-community-devs.20.26.20users
 
 
 
@@ -27,7 +38,10 @@ This libary contains a subset of the work that was developed in the context of t
   - Damien Rouhling
   - Pierre Roux
   - Vincent Siles (initial)
-- License: [MIT](LICENSE)
+- Coq-community maintainer(s):
+  - Cyril Cohen ([**@CohenCyril**](https://github.com/CohenCyril))
+  - Pierre Roux ([**@proux01**](https://github.com/proux01))
+- License: [MIT License](LICENSE)
 - Compatible Coq versions: 8.10 or later (use releases for other Coq versions)
 - Additional dependencies:
   - [Bignums](https://github.com/coq/bignums) same version as Coq
@@ -55,8 +69,8 @@ opam install coq-coqeal
 To instead build and install manually, do:
 
 ``` shell
-git clone https://github.com/CoqEAL/coqeal.git
-cd coqeal
+git clone https://github.com/coq-community/CoqEAL.git
+cd CoqEAL
 make   # or make -j <number-of-cores-on-your-machine> 
 make install
 ```

--- a/coq-coqeal.opam
+++ b/coq-coqeal.opam
@@ -5,9 +5,9 @@ opam-version: "2.0"
 maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
 version: "dev"
 
-homepage: "https://github.com/CoqEAL/coqeal"
-dev-repo: "git+https://github.com/CoqEAL/coqeal.git"
-bug-reports: "https://github.com/CoqEAL/coqeal/issues"
+homepage: "https://github.com/coq-community/CoqEAL"
+dev-repo: "git+https://github.com/coq-community/CoqEAL.git"
+bug-reports: "https://github.com/coq-community/CoqEAL/issues"
 license: "MIT"
 
 synopsis: "CoqEAL - The Coq Effective Algebra Library"
@@ -21,7 +21,7 @@ install: [make "install"]
 depends: [
   "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
   "coq-bignums" 
-  "coq-paramcoq" {(>= "1.1.1") | (= "dev")}
+  "coq-paramcoq" {>= "1.1.1"}
   "coq-mathcomp-multinomials" {((>= "1.5.1" & < "1.7~") | = "dev")}
   "coq-mathcomp-algebra" {((>= "1.12.0" & < "1.14~") | = "dev")}
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -1,8 +1,9 @@
 ---
 fullname: CoqEAL
-shortname: coqeal
-organization: CoqEAL
-community: false
+shortname: CoqEAL
+opam_name: coq-coqeal
+organization: coq-community
+community: true
 action: true
 coqdoc: false
 dune: false
@@ -52,13 +53,15 @@ authors:
 maintainers:
 - name: Cyril Cohen
   nickname: CohenCyril
+- name: Pierre Roux
+  nickname: proux01
 
 opam-file-maintainer: Cyril Cohen <cyril.cohen@inria.fr>
 
 opam-file-version: dev
 
 license:
-  fullname: MIT
+  fullname: MIT License
   identifier: MIT
 
 supported_coq_versions:
@@ -72,7 +75,7 @@ dependencies:
     [Bignums](https://github.com/coq/bignums) same version as Coq
 - opam:
     name: coq-paramcoq
-    version: '{(>= "1.1.1") | (= "dev")}'
+    version: '{>= "1.1.1"}'
   description: |-
     [Paramcoq](https://github.com/coq-community/paramcoq) 1.1.1 or later
 - opam:


### PR DESCRIPTION
The metadata is currently using the fact that `coqeal` and `CoqEAL` are treated the same by GitHub, which may be confusing. If we want to have `coqeal` as the official repo name (displayed in searchers, etc.), we can rename the repo.

Also, I activated the usual buttons in `README.md` we use in coq-community.