### PR TITLE
Add %N for nat constants

### DIFF
--- a/refinements/hpoly.v
+++ b/refinements/hpoly.v
@@ -900,7 +900,7 @@ Abort.
 
 Definition test := [coqeal simpl of sizep (1 + 2%:Z *: 'X + 3%:Z *: 'X^2)].
 
-Goal (sizep (1 + 2%:Z *: 'X + 3%:Z *: 'X^2) = 3).
+Goal (sizep (1 + 2%:Z *: 'X + 3%:Z *: 'X^2) = 3%N).
 by coqeal.
 Qed.
 

--- a/refinements/karatsuba.v
+++ b/refinements/karatsuba.v
@@ -157,11 +157,11 @@ Fixpoint bigpoly (x : int) (n : nat) : {poly int} :=
   | n.+1 => x%:P + (bigpoly (x+1) n) * 'X
   end.
 
-Let p1 := Eval compute in bigseq 1 10.
-Let p2 := Eval compute in bigseq 2 10.
+Let p1 := Eval compute in bigseq 1%N 10.
+Let p2 := Eval compute in bigseq 2%N 10.
 
-Let q1 := Eval simpl in bigpoly 1 10.
-Let q2 := Eval simpl in bigpoly 2 10.
+Let q1 := Eval simpl in bigpoly 1%N 10.
+Let q2 := Eval simpl in bigpoly 2%N 10.
 
 (* TODO: Translate Poly directly? *)
 Goal (Poly p1 * Poly p2 == Poly p2 * Poly p1).

--- a/refinements/seqmx.v
+++ b/refinements/seqmx.v
@@ -1453,9 +1453,9 @@ Goal (Mp *m 0 == 0 :> 'M[_]_(2,2)).
 by coqeal.
 Abort.
 
-Definition M := \matrix_(i,j < 2) 1%nat%num%:Z.
-Definition N := \matrix_(i,j < 2) 2%num%:Z.
-Definition P := \matrix_(i,j < 2) 14%num%:Z.
+Definition M := \matrix_(i,j < 2) 1%:Z.
+Definition N := \matrix_(i,j < 2) 2%:Z.
+Definition P := \matrix_(i,j < 2) 14%:Z.
 
 Goal (M + N + M + N + M + N + N + M + N) *m
    (M + N + M + N + M + N + N + M + N) =

--- a/refinements/seqpoly.v
+++ b/refinements/seqpoly.v
@@ -730,7 +730,7 @@ Goal (sizep ('X^2 : {poly int}) ==
 by coqeal.
 Abort.
 
-Goal (sizep (1 + 2%:Z *: 'X + 3%:Z *: 'X^2) == 3).
+Goal (sizep (1 + 2%:Z *: 'X + 3%:Z *: 'X^2) == 3%N).
 by coqeal.
 Abort.
 

--- a/theory/kaplansky.v
+++ b/theory/kaplansky.v
@@ -112,7 +112,7 @@ Lemma smith1xnP n (M : 'M[R]_(1,1 + (1 + n)))
   (smith2xnP : forall M, smith_spec M (smith2xn M))  :
   smith_spec M (smith1xn smith2xn M).
 Proof.
-rewrite /smith1xn; case: smith2xnP; rewrite [2]/(1+1)%N=> P d Q h_eq hs hP hQ.
+rewrite /smith1xn; case: smith2xnP; rewrite [2%N]/(1+1)%N=> P d Q h_eq hs hP hQ.
 have [d0|d_neq0] := (boolP (d`_0 == 0)).
   constructor; rewrite ?unitmx1 // ?simplmx; apply/matrixP=> i j.
   move/(canRL (mulmxK hQ))/(canRL (mulKmx hP))/matrixP: h_eq.


### PR DESCRIPTION
This is in preparation of
https://github.com/math-comp/math-comp/pull/841

This is backward compatible (it only ensures that natural number
constants will kee being interpreted in nat_scope when a number
notation will be added in ring_scope).