### PR TITLE
Replace paramcoq with elpi derive.param2

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,18 +17,9 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp:2.1.0-coq-8.16'
-          - 'mathcomp/mathcomp:2.1.0-coq-8.17'
-          - 'mathcomp/mathcomp:2.1.0-coq-8.18'
-          - 'mathcomp/mathcomp:2.2.0-coq-8.16'
-          - 'mathcomp/mathcomp:2.2.0-coq-8.17'
-          - 'mathcomp/mathcomp:2.2.0-coq-8.18'
-          - 'mathcomp/mathcomp:2.2.0-coq-8.19'
           - 'mathcomp/mathcomp:2.2.0-coq-8.20'
           - 'mathcomp/mathcomp:2.3.0-coq-8.20'
           - 'mathcomp/mathcomp:2.3.0-coq-dev'
-          - 'mathcomp/mathcomp-dev:coq-8.18'
-          - 'mathcomp/mathcomp-dev:coq-8.19'
           - 'mathcomp/mathcomp-dev:coq-8.20'
           - 'mathcomp/mathcomp-dev:coq-dev'
       fail-fast: false

--- a/.github/workflows/nix-action-coq-8.20.yml
+++ b/.github/workflows/nix-action-coq-8.20.yml
@@ -245,10 +245,6 @@ jobs:
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.20"
         --argstr job "bignums"
     - if: steps.stepCheck.outputs.status == 'built'
-      name: 'Building/fetching previous CI target: paramcoq'
-      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.20"
-        --argstr job "paramcoq"
-    - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: multinomials'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.20"
         --argstr job "multinomials"

--- a/.nix/config.nix
+++ b/.nix/config.nix
@@ -31,8 +31,8 @@
   ## Cachix caches to use in CI
   ## Below we list some standard ones
   cachix.coq = {};
-  cachix.coq-community = {};
-  cachix.math-comp.authToken = "CACHIX_AUTH_TOKEN";
+  cachix.math-comp.authToken = {};
+  cachix.coq-community = "CACHIX_AUTH_TOKEN";
 
   ## If you have write access to one of these caches you can
   ## provide the auth token or signing key through a secret
@@ -130,7 +130,7 @@
       coq-elpi.override.version = "master";
       coq-elpi.override.elpi-version = "2.0.7";
       hierarchy-builder.override.version = "master";
-      mathcomp.override.version = "2.2.0";
+      mathcomp.override.version = "2.3.0";
     };
   };
 }

--- a/.nix/config.nix
+++ b/.nix/config.nix
@@ -124,6 +124,7 @@
       mathcomp-real-closed.override.version = "master";
       stdlib.override.version = "master";
       bignums.override.version = "master";
+      mathcomp-apery.override.version = "coqeal_99";
     };
     "coq-8.20".coqPackages = common-bundles // {
       coq.override.version = "8.20";
@@ -131,6 +132,7 @@
       coq-elpi.override.elpi-version = "2.0.7";
       hierarchy-builder.override.version = "master";
       mathcomp.override.version = "2.3.0";
+      mathcomp-apery.override.version = "coqeal_99";
     };
   };
 }

--- a/.nix/coq-overlays/coqeal/default.nix
+++ b/.nix/coq-overlays/coqeal/default.nix
@@ -1,0 +1,124 @@
+{
+  coq,
+  mkCoqDerivation,
+  mathcomp,
+  bignums,
+  paramcoq,
+  multinomials,
+  mathcomp-real-closed,
+  lib,
+  version ? null,
+}:
+
+let
+derivation = mkCoqDerivation {
+
+  pname = "CoqEAL";
+
+  inherit version;
+  defaultVersion =
+    with lib.versions;
+    lib.switch
+      [ coq.version mathcomp.version ]
+      [
+        {
+          cases = [
+            (range "8.16" "8.20")
+            (isGe "2.1.0")
+          ];
+          out = "2.0.3";
+        }
+        {
+          cases = [
+            (range "8.16" "8.20")
+            (isGe "2.0.0")
+          ];
+          out = "2.0.1";
+        }
+        {
+          cases = [
+            (range "8.16" "8.17")
+            (isGe "2.0.0")
+          ];
+          out = "2.0.0";
+        }
+        {
+          cases = [
+            (range "8.15" "8.18")
+            (range "1.15.0" "1.18.0")
+          ];
+          out = "1.1.3";
+        }
+        {
+          cases = [
+            (range "8.13" "8.17")
+            (range "1.13.0" "1.18.0")
+          ];
+          out = "1.1.1";
+        }
+        {
+          cases = [
+            (range "8.10" "8.15")
+            (range "1.12.0" "1.18.0")
+          ];
+          out = "1.1.0";
+        }
+        {
+          cases = [
+            (isGe "8.10")
+            (range "1.11.0" "1.12.0")
+          ];
+          out = "1.0.5";
+        }
+        {
+          cases = [
+            (isGe "8.7")
+            "1.11.0"
+          ];
+          out = "1.0.4";
+        }
+        {
+          cases = [
+            (isGe "8.7")
+            "1.10.0"
+          ];
+          out = "1.0.3";
+        }
+      ]
+      null;
+
+  release."2.0.3".sha256 = "sha256-5lDq7IWlEW0EkNzYPu+dA6KOvRgy53W/alikpDr/Kd0=";
+  release."2.0.1".sha256 = "sha256-d/IQ4IdS2tpyPewcGobj2S6m2HU+iXQmlvR+ITNIcjI=";
+  release."2.0.0".sha256 = "sha256-SG/KVnRJz2P+ZxkWVp1dDOnc/JVgigoexKfRUh1Y0GM";
+  release."1.1.3".sha256 = "sha256-xhqWpg86xbU1GbDtXXInNCTArjjPnWZctWiiasq1ScU=";
+  release."1.1.1".sha256 = "sha256-ExAdC3WuArNxS+Sa1r4x5aT7ylbCvP/BZXfkdQNAvZ8=";
+  release."1.1.0".sha256 = "1vyhfna5frkkq2fl1fkg2mwzpg09k3sbzxxpyp14fjay81xajrxr";
+  release."1.0.6".sha256 = "0lqkyfj4qbq8wr3yk8qgn7mclw582n3fjl9l19yp8cnchspzywx0";
+  release."1.0.5".sha256 = "0cmvky8glb5z2dy3q62aln6qbav4lrf2q1589f6h1gn5bgjrbzkm";
+  release."1.0.4".sha256 = "1g5m26lr2lwxh6ld2gykailhay4d0ayql4bfh0aiwqpmmczmxipk";
+  release."1.0.3".sha256 = "0hc63ny7phzbihy8l7wxjvn3haxx8jfnhi91iw8hkq8n29i23v24";
+
+  propagatedBuildInputs = [
+    mathcomp.algebra
+    bignums
+    multinomials
+  ];
+
+  meta = {
+    description = "CoqEAL - The Coq Effective Algebra Library";
+    license = lib.licenses.mit;
+  };
+};
+patched-derivation1 = derivation.overrideAttrs
+  (o: {
+    propagatedBuildInputs =
+      o.propagatedBuildInputs
+      ++ lib.optional (lib.versions.isGe "1.1" o.version || o.version == "dev") mathcomp-real-closed;
+  });
+patched-derivation = patched-derivation1.overrideAttrs
+  (o: {
+    propagatedBuildInputs =
+      o.propagatedBuildInputs
+      ++ lib.optional (lib.versions.isLe "2.0.3" o.version && o.version != "dev") paramcoq;
+  });
+in patched-derivation

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ of the ForMath EU FP7 project (2009-2013). It has two parts:
 - Compatible Coq versions: 8.16 or later (use releases for other Coq versions)
 - Additional dependencies:
   - [Bignums](https://github.com/coq/bignums) same version as Coq
-  - [Paramcoq](https://github.com/coq-community/paramcoq) 1.1.3 or later
+  - [Coq-Elpi](https://github.com/LPCIC/coq-elpi) 2.4.1 or later
   - [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder) 1.4.0 or later
   - [MathComp ssreflect](https://math-comp.github.io) 2.1 or later
   - [MathComp algebra](https://math-comp.github.io) 2.1 or later

--- a/coq-coqeal.opam
+++ b/coq-coqeal.opam
@@ -23,7 +23,7 @@ install: [make "install"]
 depends: [
   "coq" {(>= "8.16" & < "8.21~") | (= "dev")}
   "coq-bignums" 
-  "coq-paramcoq" {>= "1.1.3"}
+  "coq-elpi" {>= "2.4.1"}
   "coq-hierarchy-builder" {>= "1.4.0"}
   "coq-mathcomp-ssreflect" {>= "2.1"}
   "coq-mathcomp-algebra" 

--- a/meta.yml
+++ b/meta.yml
@@ -85,10 +85,10 @@ dependencies:
   description: |-
     [Bignums](https://github.com/coq/bignums) same version as Coq
 - opam:
-    name: coq-paramcoq
-    version: '{>= "1.1.3"}'
+    name: coq-elpi
+    version: '{>= "2.4.1"}'
   description: |-
-    [Paramcoq](https://github.com/coq-community/paramcoq) 1.1.3 or later
+    [Coq-Elpi](https://github.com/LPCIC/coq-elpi) 2.4.1 or later
 - opam:
     name: coq-hierarchy-builder
     version: '{>= "1.4.0"}'
@@ -115,30 +115,12 @@ dependencies:
     [MathComp real-closed](https://math-comp.github.io) 2.0 or later
 
 tested_coq_opam_versions:
-- version: '2.1.0-coq-8.16'
-  repo: 'mathcomp/mathcomp'
-- version: '2.1.0-coq-8.17'
-  repo: 'mathcomp/mathcomp'
-- version: '2.1.0-coq-8.18'
-  repo: 'mathcomp/mathcomp'
-- version: '2.2.0-coq-8.16'
-  repo: 'mathcomp/mathcomp'
-- version: '2.2.0-coq-8.17'
-  repo: 'mathcomp/mathcomp'
-- version: '2.2.0-coq-8.18'
-  repo: 'mathcomp/mathcomp'
-- version: '2.2.0-coq-8.19'
-  repo: 'mathcomp/mathcomp'
 - version: '2.2.0-coq-8.20'
   repo: 'mathcomp/mathcomp'
 - version: '2.3.0-coq-8.20'
   repo: 'mathcomp/mathcomp'
 - version: '2.3.0-coq-dev'
   repo: 'mathcomp/mathcomp'
-- version: 'coq-8.18'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.19'
-  repo: 'mathcomp/mathcomp-dev'
 - version: 'coq-8.20'
   repo: 'mathcomp/mathcomp-dev'
 - version: 'coq-dev'

--- a/refinements/bareiss_eff.v
+++ b/refinements/bareiss_eff.v
@@ -63,10 +63,11 @@ Definition bdet n (M : mxR (1 + n) (1 + n)) := head (bareiss_char_poly (- M)%C).
 
 End generic_bareiss.
 
-Parametricity bareiss_rec.
-Parametricity bareiss.
-Parametricity bareiss_char_poly.
-Parametricity bdet.
+Elpi derive.param2 hmul_op.
+Elpi derive.param2 bareiss_rec.
+Elpi derive.param2 bareiss.
+Elpi derive.param2 bareiss_char_poly.
+Elpi derive.param2 bdet.
 
 (* First some general lemmas *)
 Section prelude.
@@ -301,7 +302,7 @@ Context `{forall m1 m2 (rm : nat_R m1 m2) n1 n2 (rn : nat_R n1 n2),
           refines ((RpolyC ==> RpolyC) ==> RmxpolyC rm rn ==> RmxpolyC rm rn)
                   (fun f => @matrix.map_mx _ _ f m1 n1) (@map_mxC m2 n2)}.
 Context `{forall m1 m2 (rm : nat_R m1 m2),
-          refines (RmxpolyC (nat_R_S_R rm) (nat_R_S_R rm) ==> RpolyC)
+          refines (RmxpolyC (S_R rm) (S_R rm) ==> RpolyC)
                   (@top_left m1) (@top_leftC m2)}.
 Context `{!refines (RpolyC ==> RpolyC ==> RpolyC) (@rdivp R) divpC}.
 Context `{forall n1 n2 (rn : nat_R n1 n2),
@@ -309,33 +310,49 @@ Context `{forall n1 n2 (rn : nat_R n1 n2),
                   (@char_poly_mxC n2)}.
 Context `{!refines (RpolyC ==> rC) head headC}.
 
+#[export] Instance RmxpolyC_ursubmx :
+  refines (ursubmx_of_R (@RmxpolyC)) ursubmx ursubmxC.
+Proof. by rewrite /ursubmx_of_R refinesE => *; apply: refinesP. Qed.
+
+#[export] Instance RmxpolyC_dlsubmx :
+  refines (dlsubmx_of_R (@RmxpolyC)) dlsubmx dlsubmxC.
+Proof. by rewrite /dlsubmx_of_R refinesE => *; apply: refinesP. Qed.
+
+#[export] Instance RmxpolyC_drsubmx :
+  refines (drsubmx_of_R (@RmxpolyC)) drsubmx drsubmxC.
+Proof. by rewrite /drsubmx_of_R refinesE => *; apply: refinesP. Qed.
+
+#[export] Instance RmxpolyC_hmul :
+  refines (hmul_of_R (@RmxpolyC)) hmul_of_instance_0 hmul_of0.
+Proof. by rewrite /hmul_of_R refinesE => *; apply: refinesP. Qed.
+
 #[export] Instance RpolyC_bareiss_rec m1 m2 (rm : nat_R m1 m2) :
-  refines (RpolyC ==> RmxpolyC (nat_R_S_R rm) (nat_R_S_R rm) ==> RpolyC)
+  refines (RpolyC ==> RmxpolyC (S_R rm) (S_R rm) ==> RpolyC)
           (bareiss_rec (polyR:={poly R}) (mxpolyR:=matrix {poly R}) (m:=m1))
           (bareiss_rec (polyR:=polyC) (mxpolyR:=mxpolyC) (m:=m2)).
 Proof. param bareiss_rec_R. Qed.
 
 #[export] Instance refine_bareiss_rec m :
-  refines (RpolyC ==> RmxpolyC (nat_R_S_R (nat_Rxx m)) (nat_R_S_R (nat_Rxx m))
+  refines (RpolyC ==> RmxpolyC (S_R (nat_Rxx m)) (S_R (nat_Rxx m))
                   ==> RpolyC)
           (bareiss_rec (polyR:={poly R}) (mxpolyR:=matrix {poly R}) (m:=m))
           (bareiss_rec (polyR:=polyC) (mxpolyR:=mxpolyC) (m:=m)).
 Proof. exact: RpolyC_bareiss_rec. Qed.
 
 #[export] Instance RpolyC_bareiss n1 n2 (rn : nat_R n1 n2) :
-  refines (RmxpolyC (nat_R_S_R rn) (nat_R_S_R rn) ==> RpolyC)
+  refines (RmxpolyC (S_R rn) (S_R rn) ==> RpolyC)
           (bareiss (polyR:={poly R}) (mxpolyR:=matrix {poly R}) (n:=n1))
           (bareiss (polyR:=polyC) (mxpolyR:=mxpolyC) (n:=n2)).
 Proof. param bareiss_R. Qed.
 
 #[export] Instance refine_bareiss n :
-  refines (RmxpolyC (nat_R_S_R (nat_Rxx n)) (nat_R_S_R (nat_Rxx n)) ==> RpolyC)
+  refines (RmxpolyC (S_R (nat_Rxx n)) (S_R (nat_Rxx n)) ==> RpolyC)
           (bareiss (polyR:={poly R}) (mxpolyR:=matrix {poly R}) (n:=n))
           (bareiss (polyR:=polyC) (mxpolyR:=mxpolyC) (n:=n)).
 Proof. exact: RpolyC_bareiss. Qed.
 
 #[export] Instance RpolyC_bareiss_char_poly n1 n2 (rn : nat_R n1 n2) :
-  refines (RmxC (nat_R_S_R rn) (nat_R_S_R rn) ==> RpolyC)
+  refines (RmxC (S_R rn) (S_R rn) ==> RpolyC)
           (bareiss_char_poly (polyR:={poly R}) (mxR:=matrix R)
                              (mxpolyR:=matrix {poly R}) (@char_poly_mx R)
                              (n:=n1))
@@ -344,7 +361,7 @@ Proof. exact: RpolyC_bareiss. Qed.
 Proof. param bareiss_char_poly_R. Qed.
 
 #[export] Instance refine_bareiss_char_poly n :
-  refines (RmxC (nat_R_S_R (nat_Rxx n)) (nat_R_S_R (nat_Rxx n)) ==> RpolyC)
+  refines (RmxC (S_R (nat_Rxx n)) (S_R (nat_Rxx n)) ==> RpolyC)
           (bareiss_char_poly (polyR:={poly R}) (mxR:=matrix R)
                              (mxpolyR:=matrix {poly R}) (@char_poly_mx R)
                              (n:=n))
@@ -353,16 +370,16 @@ Proof. param bareiss_char_poly_R. Qed.
 Proof. exact: RpolyC_bareiss_char_poly. Qed.
 
 #[export] Instance RC_bdet n1 n2 (rn : nat_R n1 n2) :
-  refines (RmxC (nat_R_S_R rn) (nat_R_S_R rn) ==> rC)
+  refines (RmxC (S_R rn) (S_R rn) ==> rC)
           (bdet (R:=R) (polyR:={poly R}) (mxR:=matrix R)
                 (mxpolyR:=matrix {poly R}) (@char_poly_mx R) head
                 (n:=n1))
           (bdet (R:=C) (polyR:=polyC) (mxR:=mxC) (mxpolyR:=mxpolyC)
                 char_poly_mxC headC (n:=n2)).
-Proof. param bdet_R. Qed.
+Proof. by param bdet_R; rewrite /opp_of_R refinesE => *; apply: refinesP. Qed.
 
 #[export] Instance refine_bdet n :
-  refines (RmxC (nat_R_S_R (nat_Rxx n)) (nat_R_S_R (nat_Rxx n)) ==> rC)
+  refines (RmxC (S_R (nat_Rxx n)) (S_R (nat_Rxx n)) ==> rC)
           (bdet (R:=R) (polyR:={poly R}) (mxR:=matrix R)
                 (mxpolyR:=matrix {poly R}) (@char_poly_mx R) head
                 (n:=n))
@@ -371,7 +388,7 @@ Proof. param bdet_R. Qed.
 Proof. exact: RC_bdet. Qed.
 
 #[export] Instance RC_det_bdet n1 n2 (rn : nat_R n1 n2) :
-  refines (RmxC (nat_R_S_R rn) (nat_R_S_R rn) ==> rC) determinant
+  refines (RmxC (S_R rn) (S_R rn) ==> rC) determinant
           (bdet (R:=C) (polyR:=polyC) (mxpolyR:=mxpolyC) char_poly_mxC headC
                 (n:=n2)).
 Proof.
@@ -381,7 +398,7 @@ Proof.
 Qed.
 
 #[export] Instance refine_det n :
-  refines (RmxC (nat_R_S_R (nat_Rxx n)) (nat_R_S_R (nat_Rxx n)) ==> rC)
+  refines (RmxC (S_R (nat_Rxx n)) (S_R (nat_Rxx n)) ==> rC)
           determinant (bdet (R:=C) (polyR:=polyC) (mxpolyR:=mxpolyC)
                             char_poly_mxC headC (n:=n)).
 Proof. exact: RC_det_bdet. Qed.

--- a/refinements/binint.v
+++ b/refinements/binint.v
@@ -1,5 +1,6 @@
 (** This file is part of CoqEAL, the Coq Effective Algebra Library.
 (c) Copyright INRIA and University of Gothenburg, see LICENSE *)
+From elpi Require Import derive.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat div seq.
 From mathcomp Require Import path choice fintype tuple finset bigop order.
 From mathcomp Require Import ssralg zmodp ssrnum ssrint.
@@ -130,26 +131,26 @@ Context `{implem_of nat N, implem_of pos P}.
 
 End binint_op.
 
-Parametricity Z.
-Parametricity Zmatch.
-Parametricity zeroZ.
-Parametricity oneZ.
-Parametricity addZ.
-Parametricity oppZ.
-Parametricity subZ.
-Parametricity eqZ.
-Parametricity mulZ.
-Parametricity expZ.
-Parametricity leqZ.
-Parametricity ltZ.
-Parametricity cast_NZ.
-Parametricity cast_PZ.
-Parametricity cast_ZN.
-Parametricity cast_ZP.
-(* Parametricity int. *)
-(* Parametricity sum. *)
+Elpi derive.param2 Z.
+Elpi derive.param2 Zmatch.
+Elpi derive.param2 zeroZ.
+Elpi derive.param2 oneZ.
+Elpi derive.param2 addZ.
+Elpi derive.param2 oppZ.
+Elpi derive.param2 subZ.
+Elpi derive.param2 eqZ.
+Elpi derive.param2 mulZ.
+Elpi derive.param2 expZ.
+Elpi derive.param2 leqZ.
+Elpi derive.param2 ltZ.
+Elpi derive.param2 cast_NZ.
+Elpi derive.param2 cast_PZ.
+Elpi derive.param2 cast_ZN.
+Elpi derive.param2 cast_ZP.
+(* Elpi derive.param2 int. *)
+(* Elpi derive.param2 sum. *)
 (* Definition specZ_simpl := Eval cbv in specZ. *)
-(* Parametricity specZ_simpl. *)
+(* Elpi derive.param2 specZ_simpl. *)
 (* Realizer specZ as specZ_R := specZ_simpl_R. *)
 
 (******************************************************************************)
@@ -452,10 +453,10 @@ Proof.
   eapply refines_trans; tc.
   rewrite refinesE=> _ x ->.
   case: x=> n /=.
-    apply: Z_R_Zpos_R.
+    apply: Zpos_R.
     have heq : refines eq n n by rewrite refinesE.
     exact: refinesP.
-  apply: Z_R_Zneg_R.
+  apply: Zneg_R.
   have heq : refines eq (posS n) (posS n) by rewrite refinesE.
   exact: refinesP.
 Qed.

--- a/refinements/binord.v
+++ b/refinements/binord.v
@@ -56,11 +56,11 @@ Definition Rord n1 n2 (rn : nat_R n1 n2) : 'I_n1 -> binord n2 -> Type :=
   fun x y => Rnat x y.
 
 #[export] Instance Rord_0 n1 n2 (rn : nat_R n1 n2) :
-  refines (Rord (nat_R_S_R rn)) 0%R 0%C.
+  refines (Rord (S_R rn)) 0%R 0%C.
 Proof. by rewrite refinesE. Qed.
 
 #[export] Instance Rord_1 n1 n2 (rn : nat_R n1 n2) :
-  refines (Rord (nat_R_S_R rn)) Zp1 1%C.
+  refines (Rord (S_R rn)) Zp1 1%C.
 Proof.
   rewrite refinesE /Rord /Zp1 /inZp /= modn_def (nat_R_eq rn).
   by case: n2 rn.
@@ -68,7 +68,7 @@ Qed.
 
 Local Instance refines_nat_R_S n1 n2 :
   refines nat_R n1 n2 -> refines nat_R n1.+1 n2.+1.
-Proof. rewrite refinesE; exact: nat_R_S_R. Qed.
+Proof. rewrite refinesE; exact: S_R. Qed.
 
 Local Instance refines_implem_eq A B (R : A -> B -> Type)
       `{implem_of A B, !refines (eq ==> R) implem_id implem} x y :
@@ -85,7 +85,7 @@ Local Arguments opp_ord /.
 Local Arguments N.sub : simpl nomatch.
 
 #[export] Instance Rord_opp n1 n2 (rn : nat_R n1 n2) :
-  refines (Rord (nat_R_S_R rn) ==> Rord (nat_R_S_R rn)) -%R -%C.
+  refines (Rord (S_R rn) ==> Rord (S_R rn)) -%R -%C.
 Proof.
   rewrite refinesE=> x x' hx /=.
   exact: refinesP.
@@ -95,7 +95,7 @@ Local Arguments add_op /.
 Local Arguments add_ord /.
 
 #[export] Instance Rord_add n1 n2 (rn : nat_R n1 n2) :
-  refines (Rord (nat_R_S_R rn) ==> Rord (nat_R_S_R rn) ==> Rord (nat_R_S_R rn))
+  refines (Rord (S_R rn) ==> Rord (S_R rn) ==> Rord (S_R rn))
           +%R +%C.
 Proof.
   rewrite refinesE=> x x' hx y y' hy /=.
@@ -106,7 +106,7 @@ Local Arguments sub_op /.
 Local Arguments sub_ord /.
 
 #[export] Instance Rord_sub n1 n2 (rn : nat_R n1 n2) :
-  refines (Rord (nat_R_S_R rn) ==> Rord (nat_R_S_R rn) ==> Rord (nat_R_S_R rn))
+  refines (Rord (S_R rn) ==> Rord (S_R rn) ==> Rord (S_R rn))
           (fun x y => x - y) sub_op.
 Proof.
   rewrite refinesE=> x x' hx y y' hy /=.
@@ -117,7 +117,7 @@ Local Arguments mul_op /.
 Local Arguments mul_ord /.
 
 #[export] Instance Rord_mul n1 n2 (rn : nat_R n1 n2) :
-  refines (Rord (nat_R_S_R rn) ==> Rord (nat_R_S_R rn) ==> Rord (nat_R_S_R rn))
+  refines (Rord (S_R rn) ==> Rord (S_R rn) ==> Rord (S_R rn))
   (@Zp_mul _) *%C.
 Proof.
   rewrite refinesE=> x x' hx y y' hy /=.
@@ -128,7 +128,7 @@ Local Arguments eq_op /.
 Local Arguments eq_ord /.
 
 #[export] Instance Rord_eq n1 n2 (rn : nat_R n1 n2) :
-  refines (Rord (nat_R_S_R rn) ==> Rord (nat_R_S_R rn) ==> bool_R)
+  refines (Rord (S_R rn) ==> Rord (S_R rn) ==> bool_R)
           eqtype.eq_op eq_op.
 Proof.
   rewrite refinesE=> x x' hx y y' hy /=.
@@ -140,7 +140,7 @@ Local Arguments leq_op /.
 Local Arguments leq_ord /.
 
 #[export] Instance Rord_leq n1 n2 (rn : nat_R n1 n2) :
-  refines (Rord (nat_R_S_R rn) ==> Rord (nat_R_S_R rn) ==> bool_R)
+  refines (Rord (S_R rn) ==> Rord (S_R rn) ==> bool_R)
           (fun x y => (x <= y)%N) leq_op.
 Proof.
   rewrite refinesE=> x x' hx y y' hy /=.
@@ -152,7 +152,7 @@ Local Arguments lt_ord /.
 Local Opaque ltn.
 
 #[export] Instance Rord_lt n1 n2 (rn : nat_R n1 n2) :
-  refines (Rord (nat_R_S_R rn) ==> Rord (nat_R_S_R rn) ==> bool_R)
+  refines (Rord (S_R rn) ==> Rord (S_R rn) ==> bool_R)
           (fun x y => ltn x y) lt_op.
 Proof.
   rewrite refinesE=> x x' hx y y' hy /=.

--- a/refinements/binrat.v
+++ b/refinements/binrat.v
@@ -542,7 +542,8 @@ rewrite refinesE => _ a <- _ b <-; rewrite /r_ratBigQ unlock /fun_hrel /=.
 rewrite /eq_op /eq_bigQ BigQ.spec_eq_bool.
 case: (BigQ.to_Q a) => na da {a}.
 case: (BigQ.to_Q b) => nb db {b}.
-rewrite /Qeq_bool !Z2int_Qred /= /Zeq_bool -Z.eqb_compare.
+rewrite /Qeq_bool !Z2int_Qred /=.
+do ?[rewrite /Zeq_bool -Z.eqb_compare].  (* remove line when requiring Rocq >= 9.0 *)
 rewrite GRing.eqr_div ?intq_eq0 ?Posz_nat_of_pos_neq0 //.
 rewrite !nat_of_pos_Z_to_pos.
 rewrite !gez0_abs; [|by rewrite -[0%R]int2ZK Z2int_le..].

--- a/refinements/examples/irred.v
+++ b/refinements/examples/irred.v
@@ -175,7 +175,7 @@ Context (T' : Type) (N : Type).
 Context (enumT' : seq T')  `{zero_of N} `{one_of N} `{add_of N}.
 Definition card' (P' : pred T') : N := size_op [seq s <- enumT' | P' s].
 End card.
-Parametricity card'.
+Elpi derive.param2 card'.
 
 Lemma size_seqE T (s : seq T) : (@size_seq _ _ 0%N 1%N addn) s = size s.
 Proof. by elim: s => //= x s ->; rewrite [(_ + _)%C]addn1. Qed.
@@ -222,7 +222,7 @@ Definition enum_boolF2 : seq bool := [:: false; true].
 
 End enum_boolF2.
 
-Parametricity enum_boolF2.
+Elpi derive.param2 enum_boolF2.
 
 #[export] Instance refines_enum_boolF2 :
   refines (perm_eq \o list_R Rbool) (Finite.enum 'F_2) (enum_boolF2).
@@ -262,7 +262,7 @@ elim: n => [|n IHn] in p *.
 rewrite /= mem_cat.
 Admitted.
 
-Parametricity enum_npoly.
+Elpi derive.param2 enum_npoly.
 
 Section RnpolyC.
 

--- a/refinements/hpoly.v
+++ b/refinements/hpoly.v
@@ -26,8 +26,8 @@ Section hpoly.
 
 Context {A N pos : Type}.
 
-Inductive hpoly A := Pc : A -> hpoly A
-                   | PX : A -> pos -> hpoly A -> hpoly A.
+Inductive hpoly A := Pc : A -> hpoly
+                   | PX : A -> pos -> hpoly -> hpoly.
 
 Section hpoly_op.
 
@@ -166,30 +166,31 @@ Definition head_hpoly (p : hpoly A) :=
 End hpoly_op.
 End hpoly.
 
-Parametricity hpoly.
-Parametricity normalize.
-Parametricity from_seq.
-Parametricity cast_hpoly.
-Parametricity zero_hpoly.
-Parametricity one_hpoly.
-Parametricity map_hpoly.
-Parametricity opp_hpoly.
-Parametricity scale_hpoly.
-Parametricity addXn_const.
-Parametricity addXn.
-Parametricity add_hpoly.
-Parametricity sub_hpoly.
-Parametricity shift_hpoly.
-Parametricity mul_hpoly.
-Definition exp_hpoly' := Eval compute in @exp_hpoly.
-Parametricity exp_hpoly'.
-Realizer @exp_hpoly as exp_hpoly_R := exp_hpoly'_R.
-Parametricity eq0_hpoly.
-Parametricity eq_hpoly.
-Parametricity size_hpoly.
-Parametricity lead_coef_hpoly.
-Parametricity split_hpoly.
-Parametricity head_hpoly.
+Elpi derive.param2 hpoly.
+Elpi derive.param2 normalize.
+Elpi derive.param2 from_seq.
+Elpi derive.param2 cast_hpoly.
+Elpi derive.param2 zero_hpoly.
+Elpi derive.param2 one_hpoly.
+Elpi derive.param2 map_hpoly.
+Elpi derive.param2 opp_hpoly.
+Elpi derive.param2 scale_hpoly.
+Elpi derive.param2 addXn_const.
+Elpi derive.param2 addXn.
+Elpi derive.param2 add_hpoly.
+Elpi derive.param2 sub_hpoly.
+Elpi derive.param2 shift_hpoly.
+Elpi derive.param2 mul_hpoly.
+Elpi derive.param2 exp_hpoly.
+(* Definition exp_hpoly' := Eval compute in @exp_hpoly. *)
+(* Elpi derive.param2 exp_hpoly'. *)
+(* Realizer @exp_hpoly as exp_hpoly_R := exp_hpoly'_R. *)
+Elpi derive.param2 eq0_hpoly.
+Elpi derive.param2 eq_hpoly.
+Elpi derive.param2 size_hpoly.
+Elpi derive.param2 lead_coef_hpoly.
+Elpi derive.param2 split_hpoly.
+Elpi derive.param2 head_hpoly.
 
 Section hpoly_more_op.
 
@@ -712,7 +713,7 @@ Proof. param_comp mul_hpoly_R. Qed.
 Proof.
   eapply refines_trans; tc.
   rewrite refinesE; do ?move=> ?*.
-  eapply (exp_hpoly_R (N_R:=rN))=> // *;
+  eapply (@exp_hpoly_R _ _ _ _ _ rN)=> // *;
     exact: refinesP.
 Qed.
 
@@ -743,7 +744,7 @@ Proof. param_comp scale_hpoly_R. Qed.
 Proof.
   eapply refines_trans; tc.
   rewrite refinesE; do ?move=> ?*.
-  eapply (shift_hpoly_R (N_R:=rN))=> // *;
+  eapply (@shift_hpoly_R _ _ _ _ _ rN)=> // *;
   exact: refinesP.
 Qed.
 
@@ -784,7 +785,7 @@ Proof. rewrite -['X]expr1; exact: RhpolyC_scaleXn. Qed.
 Proof.
 refines_trans.
   rewrite refinesE; do ?move=> ?*.
-  eapply (split_hpoly_R (N_R:=rN))=> // *;
+  eapply (@split_hpoly_R _ _ _ _ _ rN)=> // *;
     exact: refinesP.
 Qed.
 

--- a/refinements/karatsuba.v
+++ b/refinements/karatsuba.v
@@ -46,8 +46,8 @@ Definition karatsuba p q :=
 
 End karatsuba_generic.
 
-Parametricity karatsuba_rec.
-Parametricity karatsuba.
+Elpi derive.param2 karatsuba_rec.
+Elpi derive.param2 karatsuba.
 
 Section karatsuba_correctness.
 

--- a/refinements/multipoly.v
+++ b/refinements/multipoly.v
@@ -31,7 +31,7 @@ Local Open Scope ring_scope.
 (** BEGIN FIXME this is redundant with PR CoqEAL/CoqEAL#3 *)
 Arguments refines A%type B%type R%rel _ _. (* Fix a scope issue with refines *)
 
-#[export] Hint Resolve list_R_nil_R : core.
+#[export] Hint Resolve nil_R : core.
 (** END FIXME this is redundant with PR CoqEAL/CoqEAL#3 *)
 
 (** Tip to leverage a Boolean condition *)
@@ -314,13 +314,12 @@ have [Ral|Ral] := @HdRel_dec T R a l Hdec.
 Qed.
 
 Inductive HdRelT (A : Type) (R : A -> A -> Prop) (a : A) : seq A -> Type :=
-    HdRelT_nil : HdRelT R a [::]
-  | HdRelT_cons : forall (b : A) (l : seq A), R a b -> HdRelT R a (b :: l).
+    HdRelT_nil : HdRelT [::]
+  | HdRelT_cons : forall (b : A) (l : seq A), R a b -> HdRelT (b :: l).
 
 Inductive SortedT (A : Type) (R : A -> A -> Prop) : seq A -> Type :=
-    SortedT_nil : SortedT R [::]
-  | SortedT_cons : forall (a : A) (l : seq A), SortedT R l -> HdRelT R a l -> SortedT R (a :: l).
-
+    SortedT_nil : SortedT [::]
+  | SortedT_cons : forall (a : A) (l : seq A), SortedT l -> HdRelT R a l -> SortedT (a :: l).
 
 Lemma HdRelT_dec T (R : T -> T -> Prop) a l :
   (forall a b, decidable (R a b)) -> HdRel R a l -> HdRelT R a l.
@@ -1866,13 +1865,13 @@ Proof.
 eapply refines_abstr=> f f' rf.
 eapply refines_abstr=> l l' rl.
 elim: l l' rl => [|h t IH] l'; rewrite refinesE => rl.
-{ inversion rl; apply list_R_nil_R. }
+{ inversion rl; apply nil_R. }
 move: rl; case l' => [|h' t'] rl; [by inversion rl|].
 inversion rl as [|h_ h'_ Hh t_ t'_ Ht].
 rewrite /=.
 have ->: f h = f' h'; [by apply refinesP; eapply refines_apply; tc|].
 specialize (IH t' (trivial_refines Ht)); rewrite refinesE in IH.
-by case (f' h') => //; apply list_R_cons_R.
+by case (f' h') => //; apply cons_R.
 Qed.
 
 #[export] Instance ReffmpolyC_list_of_mpoly_eff n :
@@ -1895,7 +1894,7 @@ apply: refines_trans (refine_list_of_mpoly_eff _).
 apply: (composable_imply _ _ (R2 := list_R (prod_R eq rAC))).
 rewrite composableE => l.
 elim: l => [|h t IH].
-{ case=> [|h' t']; [by move=>_; apply list_R_nil_R|].
+{ case=> [|h' t']; [by move=>_; apply nil_R|].
   move=> H; inversion H as [x X]; inversion X as [X0 X1].
   by inversion X0 as [H' Hx|H' Hx]; rewrite -Hx in X1; inversion X1. }
 case=> [|h' t'].
@@ -1909,7 +1908,7 @@ inversion X0 as [|X X' ref_X Y Y' ref_Y].
 inversion X1 as [|Z Z' ref_Z T T' ref_T].
 inversion ref_X as [x x' ref_x x0 x0' ref_x0'].
 inversion ref_Z as [u u' ref_u v v' ref_v].
-apply: list_R_cons_R; last first.
+apply: cons_R; last first.
   by apply IH; exists t''; split.
 apply/prod_RI; split; simpl.
 suff->: u' = x' by [].

--- a/refinements/param.v
+++ b/refinements/param.v
@@ -1,5 +1,5 @@
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq fintype.
-From Param Require Import Param.
+From elpi Require Import derive param2.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -9,8 +9,6 @@ Unset Printing Implicit Defensive.
   intros ; repeat match goal with
   | [ x : _ |- _ = _ ] => destruct x; reflexivity; fail
   end.
-
-#[global] Parametricity Tactic := destruct_reflexivity.
 
 (** Automation: for turning [sth_R a b] goals into mere [a = b] goals,
 do [suff_eq sth_Rxx]. *)
@@ -24,13 +22,13 @@ Ltac suff_eq Rxx :=
 Require Import ProofIrrelevance. (* for opaque terms *)
 
 (* data types *)
-Parametricity option.
-Parametricity unit.
-Parametricity bool.
-#[export] Hint Resolve bool_R_true_R bool_R_false_R : core.
-Parametricity nat.
-Parametricity list.
-Parametricity prod.
+Elpi derive.param2 option.
+Elpi derive.param2 unit.
+Elpi derive.param2 bool.
+#[export] Hint Resolve true_R false_R : core.
+Elpi derive.param2 nat.
+Elpi derive.param2 list.
+Elpi derive.param2 prod.
 
 Lemma bool_Rxx b : bool_R b b.
 Proof. by case: b. Qed.
@@ -38,14 +36,14 @@ Proof. by case: b. Qed.
 Lemma nat_Rxx n : nat_R n n.
 Proof.
   elim: n=> [|n];
-    [ exact: nat_R_O_R | exact: nat_R_S_R ].
+    [ exact: O_R | exact: S_R ].
 Qed.
 
 Lemma list_Rxx T (rT : T -> T -> Type) l :
   (forall x, rT x x) -> list_R rT l l.
 Proof.
-move=> Hr; elim: l=> [|h t IH]; [exact: list_R_nil_R|].
-exact: list_R_cons_R.
+move=> Hr; elim: l=> [|h t IH]; [exact: nil_R|].
+exact: cons_R.
 Qed.
 
 Lemma option_Rxx T (rT : T -> T -> Type) l :
@@ -53,102 +51,370 @@ Lemma option_Rxx T (rT : T -> T -> Type) l :
 Proof. by move=> Hr; case: l => *; constructor. Qed.
 
 (** ssrfun *)
-Parametricity simpl_fun.
+Elpi derive.param2 simpl_fun.
 
 (** ssrbool *)
-Parametricity SimplRel.
-Parametricity orb.
-Parametricity andb.
-Parametricity implb.
-Parametricity negb.
-Parametricity addb.
-Parametricity eqb.
+Elpi derive.param2 pred.
+Elpi derive.param2 rel.
+Elpi derive.param2 simpl_pred.
+Elpi derive.param2 simpl_rel.
+Elpi derive.param2 SimplPred.
+Elpi derive.param2 SimplRel.
+Elpi derive.param2 orb.
+Elpi derive.param2 andb.
+Elpi derive.param2 implb.
+Elpi derive.param2 negb.
+Elpi derive.param2 addb.
+Elpi derive.param2 eqb.
 
 (** ssrnat *)
-Parametricity subn_rec.
-Parametricity subn.
-Parametricity addn_rec.
-Parametricity addn.
-Parametricity eqn.
+Elpi derive.param2 Nat.sub.
+Elpi derive.param2 subn.
+Elpi derive.param2 subn_rec.
+Elpi derive.param2 Nat.add.
+Elpi derive.param2 addn.
+Elpi derive.param2 addn_rec.
+Elpi derive.param2 addn.
+Elpi derive.param2 eqn.
 
 (* This trick avoids having to apply Parametricity to eqtype structure *)
 Opaque eqn subn.
 Definition leqn := Eval cbv in leq.
-Parametricity leqn.
-Realizer leq as leq_R := leqn_R.
+Elpi derive.param2 leqn.
+Definition leq_R := leqn_R.
+Elpi Accumulate derive Db derive.param2.db.
+Elpi Accumulate derive.param2.db "
+:before ""param:fail""
+param {{ @leq }} {{ @leq }} {{ @leq_R }}.
+".
 
-Parametricity Logic.eq.
+Elpi derive.param2 Logic.eq.
 
 (* geq, ltn and gtn use SimplRel, not sure how well they will work in
    proofs... *)
-Parametricity geq.
-Parametricity ltn.
-Parametricity gtn.
+Elpi derive.param2 geq.
+Elpi derive.param2 ltn.
+Elpi derive.param2 gtn.
 
-Parametricity maxn.
-Parametricity minn.
-Parametricity iter.
-Parametricity iteri.
-Parametricity iterop.
-Parametricity muln_rec.
-Parametricity muln.
-Parametricity expn_rec.
-Parametricity expn.
-Parametricity fact_rec.
-Parametricity factorial.
-Parametricity odd.
-Parametricity double_rec.
-Parametricity double.
-Parametricity half.
+Elpi derive.param2 maxn.
+Elpi derive.param2 minn.
+Elpi derive.param2 iter.
+Elpi derive.param2 iteri.
+Elpi derive.param2 iterop.
+Elpi derive.param2 Nat.mul.
+Elpi derive.param2 muln.
+Elpi derive.param2 muln_rec.
+Elpi derive.param2 expn.
+Elpi derive.param2 expn_rec.
+Elpi derive.param2 factorial.
+Elpi derive.param2 fact_rec.
+Elpi derive.param2 odd.
+Elpi derive.param2 double.
+Elpi derive.param2 double_rec.
+
+(* Obtained from paramcoq *)
+Definition half_R :=
+let fix_half_1 : forall _ : nat, nat :=
+  fix half (n : nat) : nat :=
+    match n return nat with
+    | @O => n
+    | @S n' => uphalf n'
+    end
+  with uphalf (n : nat) : nat :=
+    match n return nat with
+    | @O => n
+    | @S n' => S (half n')
+    end
+  for
+  half in
+let fix_half_2 : forall _ : nat, nat :=
+  fix half (n : nat) : nat :=
+    match n return nat with
+    | @O => n
+    | @S n' => uphalf n'
+    end
+  with uphalf (n : nat) : nat :=
+    match n return nat with
+    | @O => n
+    | @S n' => S (half n')
+    end
+  for
+  half in
+let fix_uphalf_1 : forall _ : nat, nat :=
+  fix half (n : nat) : nat :=
+    match n return nat with
+    | @O => n
+    | @S n' => uphalf n'
+    end
+  with uphalf (n : nat) : nat :=
+    match n return nat with
+    | @O => n
+    | @S n' => S (half n')
+    end
+  for
+  uphalf in
+let fix_uphalf_2 : forall _ : nat, nat :=
+  fix half (n : nat) : nat :=
+    match n return nat with
+    | @O => n
+    | @S n' => uphalf n'
+    end
+  with uphalf (n : nat) : nat :=
+    match n return nat with
+    | @O => n
+    | @S n' => S (half n')
+    end
+  for
+  uphalf in
+fix half_R (n₁ n₂ : nat) (n_R : nat_R n₁ n₂) {struct n_R} : nat_R (fix_half_1 n₁) (fix_half_2 n₂) :=
+  let gen_path :
+    let half : forall _ : nat, nat :=
+      fix half (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => uphalf n'
+        end
+      with uphalf (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => S (half n')
+        end
+      for
+      half in
+    let uphalf : forall _ : nat, nat :=
+      fix half0 (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => uphalf n'
+        end
+      with uphalf (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => S (half0 n')
+        end
+      for
+      uphalf in
+    forall n : nat, @eq nat match n return nat with
+                            | @O => n
+                            | @S n' => uphalf n'
+                            end (half n) :=
+    let half : forall _ : nat, nat :=
+      fix half (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => uphalf n'
+        end
+      with uphalf (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => S (half n')
+        end
+      for
+      half in
+    let uphalf : forall _ : nat, nat :=
+      fix half0 (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => uphalf n'
+        end
+      with uphalf (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => S (half0 n')
+        end
+      for
+      uphalf in
+    fun n : nat =>
+    match n as n0 return (@eq nat match n0 return nat with
+                                  | @O => n0
+                                  | @S n' => uphalf n'
+                                  end (half n0)) with
+    | @O => @Logic.eq_refl nat (half O)
+    | @S n0 => (fun n1 : nat => @Logic.eq_refl nat (half (S n1))) n0
+    end in
+  @eq_rect nat match n₁ return nat with
+               | @O => n₁
+               | @S n' => fix_uphalf_1 n'
+               end (fun x : nat => nat_R x (fix_half_2 n₂))
+    (@eq_rect nat match n₂ return nat with
+                  | @O => n₂
+                  | @S n' => fix_uphalf_2 n'
+                  end (fun x : nat => nat_R match n₁ return nat with
+                                            | @O => n₁
+                                            | @S n' => fix_uphalf_1 n'
+                                            end x)
+       match
+         n_R in (nat_R n₁0 n₂0)
+         return
+           (nat_R match n₁0 return nat with
+                  | @O => n₁
+                  | @S n' => fix_uphalf_1 n'
+                  end match n₂0 return nat with
+                      | @O => n₂
+                      | @S n' => fix_uphalf_2 n'
+                      end)
+       with
+       | @O_R => n_R
+       | @S_R n'₁ n'₂ n'_R => uphalf_R n'₁ n'₂ n'_R
+       end (fix_half_2 n₂) (gen_path n₂)) (fix_half_1 n₁) (gen_path n₁)
+with uphalf_R (n₁ n₂ : nat) (n_R : nat_R n₁ n₂) {struct n_R} : nat_R (fix_uphalf_1 n₁) (fix_uphalf_2 n₂) :=
+  let gen_path :
+    let half : forall _ : nat, nat :=
+      fix half (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => uphalf n'
+        end
+      with uphalf (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => S (half n')
+        end
+      for
+      half in
+    let uphalf : forall _ : nat, nat :=
+      fix half0 (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => uphalf n'
+        end
+      with uphalf (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => S (half0 n')
+        end
+      for
+      uphalf in
+    forall n : nat, @eq nat match n return nat with
+                            | @O => n
+                            | @S n' => S (half n')
+                            end (uphalf n) :=
+    let half : forall _ : nat, nat :=
+      fix half (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => uphalf n'
+        end
+      with uphalf (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => S (half n')
+        end
+      for
+      half in
+    let uphalf : forall _ : nat, nat :=
+      fix half0 (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => uphalf n'
+        end
+      with uphalf (n : nat) : nat :=
+        match n return nat with
+        | @O => n
+        | @S n' => S (half0 n')
+        end
+      for
+      uphalf in
+    fun n : nat =>
+    match n as n0 return (@eq nat match n0 return nat with
+                                  | @O => n0
+                                  | @S n' => S (half n')
+                                  end (uphalf n0)) with
+    | @O => @Logic.eq_refl nat (uphalf O)
+    | @S n0 => (fun n1 : nat => @Logic.eq_refl nat (uphalf (S n1))) n0
+    end in
+  @eq_rect nat match n₁ return nat with
+               | @O => n₁
+               | @S n' => S (fix_half_1 n')
+               end (fun x : nat => nat_R x (fix_uphalf_2 n₂))
+    (@eq_rect nat match n₂ return nat with
+                  | @O => n₂
+                  | @S n' => S (fix_half_2 n')
+                  end (fun x : nat => nat_R match n₁ return nat with
+                                            | @O => n₁
+                                            | @S n' => S (fix_half_1 n')
+                                            end x)
+       match
+         n_R in (nat_R n₁0 n₂0)
+         return
+           (nat_R match n₁0 return nat with
+                  | @O => n₁
+                  | @S n' => S (fix_half_1 n')
+                  end match n₂0 return nat with
+                      | @O => n₂
+                      | @S n' => S (fix_half_2 n')
+                      end)
+       with
+       | @O_R => n_R
+       | @S_R n'₁ n'₂ n'_R => @S_R (fix_half_1 n'₁) (fix_half_2 n'₂) (half_R n'₁ n'₂ n'_R)
+       end (fix_uphalf_2 n₂) (gen_path n₂)) (fix_uphalf_1 n₁) (gen_path n₁)
+for
+half_R.
+Elpi Accumulate derive Db derive.param2.db.
+Elpi Accumulate derive.param2.db "
+:before ""param:fail""
+param {{ @half }} {{ @half }} {{ @half_R }}.
+".
+(* Elpi derive.param2 half. (* requires mutual inductives *) *)
 
 (** seq *)
 
 (* Here we must make the implicit argument in size explicit *)
-Parametricity size.
+Elpi derive.param2 size.
 
 Definition nilp' T (s : seq T) := eqn (size s) 0.
-Parametricity nilp'.
-Realizer nilp as nilp_R := nilp'_R.
+Elpi derive.param2 nilp'.
+Definition nilp_R := nilp'_R.
+Elpi Accumulate derive.param2.db "
+:before ""param:fail""
+param {{ @nilp }} {{ @nilp }} {{ @nilp_R }}.
+".
 
-Parametricity ohead.
-Parametricity head.
-Parametricity behead.
-Parametricity ncons.
-Parametricity nseq.
-Parametricity cat.
-Parametricity rcons.
-Parametricity last.
-Parametricity belast.
-Parametricity nth.
-Parametricity set_nth.
-Parametricity find.
-Parametricity filter.
-Parametricity count.
-Parametricity has.
-Parametricity all.
-Parametricity drop.
-Parametricity take.
-Parametricity rot.
-Parametricity rotr.
-Parametricity catrev.
-Parametricity rev.
-Parametricity map.
-Parametricity pmap.
-Parametricity iota.
-Parametricity mkseq.
-Parametricity foldr.
-Parametricity sumn.
-Parametricity foldl.
-Parametricity pairmap.
-Parametricity scanl.
-Parametricity zip.
-Parametricity unzip1.
-Parametricity unzip2.
-Parametricity flatten.
-Parametricity shape.
-Parametricity reshape.
-Parametricity allpairs.
+Elpi derive.param2 ohead.
+Elpi derive.param2 head.
+Elpi derive.param2 behead.
+Elpi derive.param2 ncons.
+Elpi derive.param2 nseq.
+Elpi derive.param2 cat.
+Elpi derive.param2 rcons.
+Elpi derive.param2 last.
+Elpi derive.param2 belast.
+Elpi derive.param2 nth.
+Elpi derive.param2 set_nth.
+Elpi derive.param2 find.
+Elpi derive.param2 filter.
+Elpi derive.param2 nat_of_bool.
+Elpi derive.param2 count.
+Elpi derive.param2 has.
+Elpi derive.param2 all.
+Elpi derive.param2 drop.
+Elpi derive.param2 take.
+Elpi derive.param2 rot.
+Elpi derive.param2 rotr.
+Elpi derive.param2 catrev.
+Elpi derive.param2 rev.
+Elpi derive.param2 map.
+Elpi derive.param2 oapp.
+Elpi derive.param2 pmap.
+Elpi derive.param2 iota.
+Elpi derive.param2 mkseq.
+Elpi derive.param2 foldr.
+Elpi derive.param2 sumn.
+Elpi derive.param2 foldl.
+Elpi derive.param2 pairmap.
+Elpi derive.param2 scanl.
+Elpi derive.param2 zip.
+Elpi derive.param2 fst.
+Elpi derive.param2 snd.
+Elpi derive.param2 unzip1.
+Elpi derive.param2 unzip2.
+Elpi derive.param2 flatten.
+Elpi derive.param2 shape.
+Elpi derive.param2 reshape.
+Elpi derive.param2 allpairs.
 
 (* fintype *)
 
-Parametricity ordinal.
+Elpi derive.param2 predArgType.
+Elpi derive.param2 is_true.
+Elpi derive.param2 ordinal.

--- a/refinements/poly_div.v
+++ b/refinements/poly_div.v
@@ -1,5 +1,6 @@
 (** This file is part of CoqEAL, the Coq Effective Algebra Library.
 (c) Copyright INRIA and University of Gothenburg, see LICENSE *)
+From elpi Require Import derive.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat div seq zmodp.
 From mathcomp Require Import path choice fintype tuple finset ssralg bigop poly polydiv.
 
@@ -50,10 +51,10 @@ Definition div_rec_poly (q : polyR) :=
 
 End generic_division.
 
-Parametricity div_rec_poly.
-Parametricity div_poly.
-Parametricity mod_poly.
-Parametricity scal_poly.
+Elpi derive.param2 div_rec_poly.
+Elpi derive.param2 div_poly.
+Elpi derive.param2 mod_poly.
+Elpi derive.param2 scal_poly.
 
 Section division_correctness.
 
@@ -170,7 +171,7 @@ Qed.
           (scal_poly (N:=N) (R:=C) (polyR:=polyC)).
 Proof.
   apply: refines_abstr2 => p p' hp q q' hq; rewrite refinesE.
-  by apply: (scal_poly_R (R_R:=rC) (polyR_R:=RpolyC)) => *; apply: refinesP.
+  by apply: (@scal_poly_R _ _ _ _ _ rC _ _ RpolyC) => *; apply: refinesP.
 Qed.
 
 #[export] Instance refine_scal_poly :

--- a/refinements/poly_op.v
+++ b/refinements/poly_op.v
@@ -1,5 +1,8 @@
+From elpi Require Import derive.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat div seq ssralg.
 From mathcomp Require Import path choice fintype tuple finset bigop poly polydiv.
+
+From CoqEAL Require Import param.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -19,6 +22,15 @@ Class lead_coef_of A polyA := lead_coef_op : polyA -> A.
 #[export] Hint Mode lead_coef_of + + : typeclass_instances.
 Class scal_of polyA N := scal_op : polyA -> polyA -> N.
 #[export] Hint Mode scal_of + + : typeclass_instances.
+
+Elpi derive.param2 shift_of.
+Elpi derive.param2 shift_op.
+Elpi derive.param2 split_of.
+Elpi derive.param2 split_op.
+Elpi derive.param2 lead_coef_of.
+Elpi derive.param2 lead_coef_op.
+Elpi derive.param2 scal_of.
+Elpi derive.param2 scal_op.
 
 End Op.
 End Poly.

--- a/refinements/rational.v
+++ b/refinements/rational.v
@@ -71,22 +71,28 @@ Context `{spec_of Z int, spec_of P pos, spec_of N nat}.
 End Q_ops.
 End Q.
 
-Parametricity zeroQ.
-Parametricity oneQ.
-Parametricity addQ.
-Parametricity mulQ.
-Parametricity oppQ.
-Parametricity eqQ.
-Parametricity leqQ.
-Parametricity ltQ.
-Parametricity invQ.
-Parametricity subQ.
-Parametricity divQ.
+Elpi derive.param2 Q.
+Elpi derive.param2 zeroQ.
+Elpi derive.param2 oneQ.
+Elpi derive.param2 addQ.
+Elpi derive.param2 mulQ.
+Elpi derive.param2 oppQ.
+Elpi derive.param2 eqQ.
+Elpi derive.param2 leqQ.
+Elpi derive.param2 ltQ.
+Elpi derive.param2 invQ.
+Elpi derive.param2 subQ.
+Elpi derive.param2 divQ.
 Definition expQnat' := Eval compute in expQnat.
-Parametricity expQnat'.
-Realizer expQnat as expQnat_R := expQnat'_R.
-Parametricity cast_ZQ.
-Parametricity cast_PQ.
+Elpi derive.param2 expQnat'.
+Definition expQnat_R := expQnat'_R.
+Elpi Accumulate derive Db derive.param2.db.
+Elpi Accumulate derive.param2.db "
+:before ""param:fail""
+param {{ @leq }} {{ @leq }} {{ @leq_R }}.
+".
+Elpi derive.param2 cast_ZQ.
+Elpi derive.param2 cast_PQ.
 
 Arguments specQ / _ _ _ _ _ : assert.
 
@@ -319,7 +325,7 @@ Proof. param_comp mulQ_R. Qed.
 Proof.
   eapply refines_trans; tc.
   rewrite refinesE; do ?move=> ?*.
-  eapply (expQnat_R (N_R:=Rnat))=> // *;
+  eapply (@expQnat_R _ _ _ _ _ _ _ _ Rnat)=> // *;
     exact: refinesP.
 Qed.
 

--- a/refinements/refinements.v
+++ b/refinements/refinements.v
@@ -1,3 +1,4 @@
+From elpi Require Import derive.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat div seq ssralg.
 (* Require Import path choice fintype tuple finset ssralg bigop poly polydiv. *)
 (* Require Import ssrint ZArith. *)
@@ -227,10 +228,10 @@ Ltac param x :=
 Ltac param_comp x := eapply refines_trans; tc; param x.
 
 #[export] Instance refines_true : refines _ _ _ :=
-  trivial_refines bool_R_true_R.
+  trivial_refines true_R.
 
 #[export] Instance refines_false : refines _ _ _ :=
-  trivial_refines bool_R_false_R.
+  trivial_refines false_R.
 
 #[export] Instance refines_negb : refines (bool_R ==> bool_R) negb negb.
 Proof. exact/trivial_refines/negb_R. Qed.
@@ -285,6 +286,29 @@ Class mod_of A := mod_op : A -> A -> A.
 Class scale_of A B := scale_op : A -> B -> B.
 #[export] Hint Mode scale_of + + : typeclass_instances.
 
+Elpi derive.param2 zero_of.
+Elpi derive.param2 zero_op.
+Elpi derive.param2 one_of.
+Elpi derive.param2 one_op.
+Elpi derive.param2 opp_of.
+Elpi derive.param2 opp_op.
+Elpi derive.param2 add_of.
+Elpi derive.param2 add_op.
+Elpi derive.param2 sub_of.
+Elpi derive.param2 sub_op.
+Elpi derive.param2 mul_of.
+Elpi derive.param2 mul_op.
+Elpi derive.param2 exp_of.
+Elpi derive.param2 exp_op.
+Elpi derive.param2 div_of.
+Elpi derive.param2 div_op.
+Elpi derive.param2 inv_of.
+Elpi derive.param2 inv_op.
+Elpi derive.param2 mod_of.
+Elpi derive.param2 mod_op.
+Elpi derive.param2 scale_of.
+Elpi derive.param2 scale_op.
+
 Class eq_of A := eq_op : A -> A -> bool.
 #[export] Hint Mode eq_of + : typeclass_instances.
 Class leq_of A := leq_op : A -> A -> bool.
@@ -294,6 +318,15 @@ Class lt_of A := lt_op : A -> A -> bool.
 Class size_of A N := size_op : A -> N.
 #[export] Hint Mode size_of + + : typeclass_instances.
 
+Elpi derive.param2 eq_of.
+Elpi derive.param2 eq_op.
+Elpi derive.param2 leq_of.
+Elpi derive.param2 leq_op.
+Elpi derive.param2 lt_of.
+Elpi derive.param2 lt_op.
+Elpi derive.param2 size_of.
+Elpi derive.param2 size_op.
+
 Class spec_of A B   := spec : A -> B.
 #[export] Hint Mode spec_of + + : typeclass_instances.
 Definition spec_id {A : Type} : spec_of A A := id.
@@ -302,6 +335,13 @@ Class implem_of A B := implem : A -> B.
 Definition implem_id {A : Type} : implem_of A A := id.
 Class cast_of A B  := cast_op : A -> B.
 #[export] Hint Mode cast_of + + : typeclass_instances.
+
+Elpi derive.param2 spec_of.
+Elpi derive.param2 spec.
+Elpi derive.param2 implem_of.
+Elpi derive.param2 implem.
+Elpi derive.param2 cast_of.
+Elpi derive.param2 cast_op.
 
 End Op.
 End Refinements.

--- a/refinements/refinements.v
+++ b/refinements/refinements.v
@@ -410,7 +410,7 @@ Tactic Notation  "context" "[" ssrpatternarg(pat) "]" tactic3(tac) :=
   tac; rewrite eqQ {Q eqQ}.
 
 Class strategy_class (C : forall T, T -> T -> Prop) :=
-   StrategyClass : C = @eq.
+   StrategyClass : C = (fun T => @eq T).
 #[export] Hint Mode strategy_class + : typeclass_instances.
 
 Class native_compute T (x y : T) := NativeCompute : x = y.

--- a/refinements/seqmx.v
+++ b/refinements/seqmx.v
@@ -96,8 +96,8 @@ Fixpoint foldl2 (f : T3 -> T1 -> T2 -> T3) z (s : seq T1) (t : seq T2) :=
 
 End extra_seq.
 
-Parametricity zipwith.
-Parametricity foldl2.
+Elpi derive.param2 zipwith.
+Elpi derive.param2 foldl2.
 
 Section seqmx_op.
 
@@ -229,58 +229,126 @@ Definition copid_seqmx m r := (seqmx1 m - pid_seqmx m m r)%C.
 
 End seqmx_op.
 
-Parametricity isSub.axioms_.
-Parametricity SubType.axioms_ as axioms___R.
-Parametricity subType.
+Elpi derive.param2 isSub.axioms_.
+Elpi derive.param2 SubType.axioms_.
+Elpi derive.param2 subType.
+Elpi derive.param2 SubType.sort.
+Elpi derive.param2 SubType.class.
 Definition eqtype_isSub_mixin_noprimproj_R T₁ T₂ (T_R : T₁ -> T₂ -> Type)
   (P₁ : pred T₁) (P₂ : pred T₂)
   (P_R : forall (t₁ : T₁) (t₂ : T₂), T_R t₁ t₂ -> bool_R (P₁ t₁) (P₂ t₂))
   S₁ S₂ (S_R : S₁ -> S₂ -> Type)
   (a₁ : SubType.axioms_ P₁ S₁) (a₂ : SubType.axioms_ P₂ S₂)
-  (a_R : axioms___R P_R S_R a₁ a₂) :=
-match a_R in axioms___R _ _ a₁ a₂
+  (a_R : axioms__R1 P_R S_R a₁ a₂) :=
+match a_R in axioms__R1 _ _ a₁ a₂
   return axioms__R P_R S_R (let (m) := a₁ in m) (let (m) := a₂ in m) with
-| @axioms___R_Class_R _ _ _ _ _ _ _ _ _ _ _ eqtype_isSub_mixin_R =>
+| @Class_R _ _ _ _ _ _ _ _ _ _ _ eqtype_isSub_mixin_R =>
     eqtype_isSub_mixin_R
 end.
-Realizer SubType.eqtype_isSub_mixin as eqtype_isSub_mixin :=
-  eqtype_isSub_mixin_noprimproj_R.
-Parametricity ord_enum_eq.
-Parametricity seqmx_of_fun.
-Parametricity mkseqmx_ord.
-Parametricity const_seqmx.
-Parametricity map_seqmx.
-Parametricity zipwith_seqmx.
-Parametricity seqmx0.
+Definition eqtype_isSub_mixin := eqtype_isSub_mixin_noprimproj_R.
+Elpi Accumulate derive Db derive.param2.db.
+Elpi Accumulate derive.param2.db "
+:before ""param:fail""
+param {{ @SubType.eqtype_isSub_mixin }} {{ @SubType.eqtype_isSub_mixin }}
+  {{ @eqtype_isSub_mixin_noprimproj_R }}.
+".
+Elpi derive.param2 nat_of_ord.
+Definition vrefl_R :=
+@eq_rect (forall (T : Type) (P : pred T) (x : T) (_ : is_true (P x)), @eq T x x)
+  (fun (T : Type) (P : pred T) (x : T) (_ : is_true (P x)) => @Logic.eq_refl T x)
+  (fun e : forall (T : Type) (P : pred T) (x : T) (_ : is_true (P x)), @eq T x x =>
+   forall (T₁ T₂ : Type) (T_R : forall (_ : T₁) (_ : T₂), Type) (P₁ : pred T₁) (P₂ : pred T₂)
+     (P_R : (fun (T₁0 T₂0 : Type) (T_R0 : forall (_ : T₁0) (_ : T₂0), Type) (b₁ : forall _ : T₁0, bool) (b₂ : forall _ : T₂0, bool) =>
+             forall (t₁ : T₁0) (t₂ : T₂0) (_ : T_R0 t₁ t₂), bool_R (b₁ t₁) (b₂ t₂)) T₁ T₂ T_R P₁ P₂) (x₁ : T₁) (x₂ : T₂) (x_R : T_R x₁ x₂)
+     (i₁ : is_true (P₁ x₁)) (i₂ : is_true (P₂ x₂))
+     (_ : (fun (b₁ b₂ : bool) (b_R : bool_R b₁ b₂) => @eq_R bool bool bool_R b₁ b₂ b_R true true true_R) (P₁ x₁) (P₂ x₂) (P_R x₁ x₂ x_R) i₁ i₂),
+   @eq_R T₁ T₂ T_R x₁ x₂ x_R x₁ x₂ x_R (e T₁ P₁ x₁ i₁) (e T₂ P₂ x₂ i₂))
+  (fun (T₁ T₂ : Type) (T_R : forall (_ : T₁) (_ : T₂), Type) (P₁ : pred T₁) (P₂ : pred T₂)
+     (P_R : (fun (T₁0 T₂0 : Type) (T_R0 : forall (_ : T₁0) (_ : T₂0), Type) (b₁ : forall _ : T₁0, bool) (b₂ : forall _ : T₂0, bool) =>
+             forall (t₁ : T₁0) (t₂ : T₂0) (_ : T_R0 t₁ t₂), bool_R (b₁ t₁) (b₂ t₂)) T₁ T₂ T_R P₁ P₂) (x₁ : T₁) (x₂ : T₂) (x_R : T_R x₁ x₂)
+     (H₁ : is_true (P₁ x₁)) (H₂ : is_true (P₂ x₂))
+     (_ : (fun (b₁ b₂ : bool) (b_R : bool_R b₁ b₂) => @eq_R bool bool bool_R b₁ b₂ b_R true true true_R) (P₁ x₁) (P₂ x₂) (P_R x₁ x₂ x_R) H₁ H₂) =>
+   @eq_refl_R T₁ T₂ T_R x₁ x₂ x_R) (@vrefl)
+  (ProofIrrelevance.proof_irrelevance (forall (T : Type) (P : pred T) (x : T) (_ : is_true (P x)), @eq T x x)
+     (fun (T : Type) (P : pred T) (x : T) (_ : is_true (P x)) => @Logic.eq_refl T x) (@vrefl))
+     : forall [T₁ T₂ : Type] [T_R : forall (_ : T₁) (_ : T₂), Type] [P₁ : pred T₁] [P₂ : pred T₂]
+         [P_R : (fun (T₁0 T₂0 : Type) (T_R0 : forall (_ : T₁0) (_ : T₂0), Type) (b₁ : forall _ : T₁0, bool) (b₂ : forall _ : T₂0, bool) =>
+                 forall (t₁ : T₁0) (t₂ : T₂0) (_ : T_R0 t₁ t₂), bool_R (b₁ t₁) (b₂ t₂)) T₁ T₂ T_R P₁ P₂] [x₁ : T₁] [x₂ : T₂] [x_R : T_R x₁ x₂]
+         [Px₁ : is_true (P₁ x₁)] [Px₂ : is_true (P₂ x₂)]
+         (_ : (fun (b₁ b₂ : bool) (b_R : bool_R b₁ b₂) => @eq_R bool bool bool_R b₁ b₂ b_R true true true_R) (P₁ x₁) (P₂ x₂) (P_R x₁ x₂ x_R) Px₁ Px₂),
+       @eq_R T₁ T₂ T_R x₁ x₂ x_R x₁ x₂ x_R (@vrefl T₁ P₁ x₁ Px₁) (@vrefl T₂ P₂ x₂ Px₂).
+Elpi Accumulate derive Db derive.param2.db.
+Elpi Accumulate derive.param2.db "
+:before ""param:fail""
+param {{ @vrefl }} {{ @vrefl }} {{ @vrefl_R }}.
+".
+Elpi derive.param2 vrefl_rect.
+Elpi derive.param2 fintype.HB_unnamed_factory_57.
+Elpi derive.param2 fintype_ordinal__canonical__eqtype_SubType.
+Elpi derive.param2 isSub.Sub.
+Elpi derive.param2 Sub.
+Elpi derive.param2 insub_eq.
+Elpi derive.param2 ord_enum_eq.
+Elpi derive.param2 seqmx.
+Elpi derive.param2 hseqmx.
+Elpi derive.param2 seqmx_of_fun.
+Elpi derive.param2 mkseqmx_ord.
+Elpi derive.param2 const_mx_of.
+Elpi derive.param2 const_seqmx.
+Elpi derive.param2 map_mx_of.
+Elpi derive.param2 map_seqmx.
+Elpi derive.param2 zipwith_seqmx.
+Elpi derive.param2 hzero_of.
+Elpi derive.param2 seqmx0.
 Definition diag_seqmx_simpl := Eval cbv in diag_seqmx.
-Parametricity diag_seqmx_simpl.
-Realizer diag_seqmx as diag_seqmx_R := diag_seqmx_simpl_R.
-Parametricity scalar_seqmx.
-Parametricity seqmx1.
-Parametricity opp_seqmx.
-Parametricity add_seqmx.
-Parametricity sub_seqmx.
-Parametricity trseqmx.
-Parametricity mul_seqmx.
-Parametricity scale_seqmx.
-Parametricity eq_seq.
-Parametricity eq_seqmx.
-Parametricity top_left_seqmx.
-Parametricity usubseqmx.
-Parametricity dsubseqmx.
-Parametricity lsubseqmx.
-Parametricity rsubseqmx.
-Parametricity ulsubseqmx.
-Parametricity ursubseqmx.
-Parametricity dlsubseqmx.
-Parametricity drsubseqmx.
-Parametricity row_seqmx.
-Parametricity col_seqmx.
-Parametricity block_seqmx.
-Parametricity delta_seqmx.
-Parametricity trace_seqmx.
-Parametricity pid_seqmx.
-Parametricity copid_seqmx.
+Elpi derive.param2 diag_seqmx_simpl.
+Definition diag_seqmx_R := diag_seqmx_simpl_R.
+Elpi Accumulate derive Db derive.param2.db.
+Elpi Accumulate derive.param2.db "
+:before ""param:fail""
+param {{ @diag_seqmx }} {{ @diag_seqmx }} {{ @diag_seqmx_R }}.
+".
+Elpi derive.param2 scalar_seqmx.
+Elpi derive.param2 seqmx1.
+Elpi derive.param2 opp_seqmx.
+Elpi derive.param2 add_seqmx.
+Elpi derive.param2 sub_seqmx.
+Elpi derive.param2 trseqmx.
+Elpi derive.param2 hmul_of.
+Elpi derive.param2 mul_seqmx.
+Elpi derive.param2 scale_seqmx.
+Elpi derive.param2 eq_seq.
+Elpi derive.param2 eq_seqmx.
+Elpi derive.param2 top_left_of.
+Elpi derive.param2 top_left_seqmx.
+Elpi derive.param2 usubmx_of.
+Elpi derive.param2 usubseqmx.
+Elpi derive.param2 dsubmx_of.
+Elpi derive.param2 dsubseqmx.
+Elpi derive.param2 lsubmx_of.
+Elpi derive.param2 lsubseqmx.
+Elpi derive.param2 rsubmx_of.
+Elpi derive.param2 rsubseqmx.
+Elpi derive.param2 ulsubmx_of.
+Elpi derive.param2 ulsubseqmx.
+Elpi derive.param2 ursubmx_of.
+Elpi derive.param2 ursubseqmx.
+Elpi derive.param2 dlsubmx_of.
+Elpi derive.param2 dlsubseqmx.
+Elpi derive.param2 drsubmx_of.
+Elpi derive.param2 drsubseqmx.
+Elpi derive.param2 row_mx_of.
+Elpi derive.param2 row_seqmx.
+Elpi derive.param2 col_mx_of.
+Elpi derive.param2 col_seqmx.
+Elpi derive.param2 block_mx_of.
+Elpi derive.param2 block_seqmx.
+Elpi derive.param2 mkseqmx_ord.
+Elpi derive.param2 delta_seqmx.
+Elpi derive.param2 trace_seqmx.
+Elpi derive.param2 pid_seqmx.
+Elpi derive.param2 pid_seqmx.
+Elpi derive.param2 copid_seqmx.
 
 Section seqmx_more_op.
 
@@ -315,7 +383,7 @@ Variant Rseqmx {m1 m2} (rm : nat_R m1 m2) {n1 n2} (rn : nat_R n1 n2) :
   Rseqmx_spec (A : 'M[R]_(m1, n1)) M of
     size M = m2
   & forall i, i < m2 -> size (nth [::] M i) = n2
-  & (forall i j, (A i j = nth 0%C (nth [::] M i) j)) : Rseqmx rm rn A M.
+  & (forall i j, (A i j = nth 0%C (nth [::] M i) j)) : Rseqmx A M.
 
 (* Definition Rord n (i : 'I_n) j := i = j :> nat. *)
 
@@ -376,7 +444,7 @@ by rewrite mxE nth_nseq -(nat_R_eq rm) ltn_ord nth_nseq -(nat_R_eq rn) ltn_ord.
 Qed.
 
 Instance Rseqmx_top_left_seqmx m1 m2 (rm : nat_R m1 m2) :
-  refines (Rseqmx (nat_R_S_R rm) (nat_R_S_R rm) ==> eq)
+  refines (Rseqmx (S_R rm) (S_R rm) ==> eq)
           (fun M => M ord0 ord0) top_left_op.
 Proof.
   rewrite refinesE=> _ _ [M sM h1 h2 h3].
@@ -672,7 +740,8 @@ Qed.
 Proof.
   eapply refines_trans; tc.
   rewrite refinesE.
-  eapply (seqmx_of_fun_R (I_R:=rI))=> // *; apply refinesP.
+  eapply (@seqmx_of_fun_R _ _ _ _ _ rI)=> // *; apply refinesP.
+    rewrite /implem_of_R refinesE => *; apply refinesP.
     eapply refines_apply; tc.
   eapply refines_comp_unify; tc.
 Qed.
@@ -700,7 +769,7 @@ Proof. exact: RseqmxC_mkseqmx_ord. Qed.
        (rn : nat_R n1 n2) :
   refines (rAC ==> RseqmxC rm rn) (@matrix.const_mx R m1 n1)
           (const_seqmx m2 n2).
-Proof. param_comp const_seqmx_R. Qed.
+Proof. param_comp const_seqmx_R. Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_const_seqmx m n :
   refines (rAC ==> RseqmxC (nat_Rxx m) (nat_Rxx n)) (@matrix.const_mx R m n)
@@ -709,20 +778,20 @@ Proof. exact: RseqmxC_const_seqmx. Qed.
 
 #[export] Instance RseqmxC_0 m1 m2 (rm : nat_R m1 m2) n1 n2 (rn : nat_R n1 n2) :
   refines (RseqmxC rm rn) (const_mx 0%C) (@hzero_op _ _ _ m2 n2).
-Proof. param_comp seqmx0_R. Qed.
+Proof. param_comp seqmx0_R. Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_0_seqmx m n :
   refines (RseqmxC (nat_Rxx m) (nat_Rxx n)) (const_mx 0%C) (@hzero_op _ _ _ m n).
 Proof. exact: RseqmxC_0. Qed.
 
 #[export] Instance RseqmxC_top_left_seqmx m1 m2 (rm : nat_R m1 m2) :
-  refines (RseqmxC (nat_R_S_R rm) (nat_R_S_R rm) ==> rAC)
+  refines (RseqmxC (S_R rm) (S_R rm) ==> rAC)
           (fun M => M ord0 ord0)
           (@top_left_seqmx C _).
 Proof. param_comp top_left_seqmx_R. Qed.
 
 #[export] Instance refine_top_left_seqmx m :
-  refines (RseqmxC (nat_R_S_R (nat_Rxx m)) (nat_R_S_R (nat_Rxx m)) ==> rAC)
+  refines (RseqmxC (S_R (nat_Rxx m)) (S_R (nat_Rxx m)) ==> rAC)
           (fun M => M ord0 ord0)
           (@top_left_seqmx C _).
 Proof. exact: RseqmxC_top_left_seqmx. Qed.
@@ -731,7 +800,8 @@ Proof. exact: RseqmxC_top_left_seqmx. Qed.
        (rm2 : nat_R m21 m22) n1 n2 (rn : nat_R n1 n2) :
   refines (RseqmxC (addn_R rm1 rm2) rn ==> RseqmxC rm1 rn)
           (@matrix.usubmx R m11 m21 n1) (@usubseqmx C m12 m22 n2).
-Proof. param_comp usubseqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp usubseqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_usubseqmx m1 m2 n :
   refines (RseqmxC (addn_R (nat_Rxx m1) (nat_Rxx m2)) (nat_Rxx n) ==>
@@ -743,7 +813,8 @@ Proof. exact: RseqmxC_usubseqmx. Qed.
        (rm2 : nat_R m21 m22) n1 n2 (rn : nat_R n1 n2) :
   refines (RseqmxC (addn_R rm1 rm2) rn ==> RseqmxC rm2 rn)
           (@matrix.dsubmx R m11 m21 n1) (@dsubseqmx C m12 m22 n2).
-Proof. param_comp dsubseqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp dsubseqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_dsubseqmx m1 m2 n :
   refines (RseqmxC (addn_R (nat_Rxx m1) (nat_Rxx m2)) (nat_Rxx n) ==>
@@ -755,7 +826,8 @@ Proof. exact: RseqmxC_dsubseqmx. Qed.
        (rn1 : nat_R n11 n12) n21 n22 (rn2 : nat_R n21 n22) :
   refines (RseqmxC rm (addn_R rn1 rn2) ==> RseqmxC rm rn1)
           (@matrix.lsubmx R m1 n11 n21) (@lsubseqmx C m2 n12 n22).
-Proof. param_comp lsubseqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp lsubseqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_lsubseqmx m n1 n2 :
   refines (RseqmxC (nat_Rxx m) (addn_R (nat_Rxx n1) (nat_Rxx n2)) ==>
@@ -767,7 +839,8 @@ Proof. exact: RseqmxC_lsubseqmx. Qed.
        (rn1 : nat_R n11 n12) n21 n22 (rn2 : nat_R n21 n22) :
   refines (RseqmxC rm (addn_R rn1 rn2) ==> RseqmxC rm rn2)
           (@matrix.rsubmx R m1 n11 n21) (@rsubseqmx C m2 n12 n22).
-Proof. param_comp rsubseqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp rsubseqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_rsubseqmx m n1 n2 :
   refines (RseqmxC (nat_Rxx m) (addn_R (nat_Rxx n1) (nat_Rxx n2)) ==>
@@ -780,7 +853,8 @@ Proof. exact: RseqmxC_rsubseqmx. Qed.
        (rn2 : nat_R n21 n22) :
   refines (RseqmxC (addn_R rm1 rm2) (addn_R rn1 rn2) ==> RseqmxC rm1 rn1)
           (@matrix.ulsubmx R m11 m21 n11 n21) (@ulsubseqmx C m12 m22 n12 n22).
-Proof. param_comp ulsubseqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp ulsubseqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_ulsubseqmx m1 m2 n1 n2 :
   refines (RseqmxC (addn_R (nat_Rxx m1) (nat_Rxx m2))
@@ -794,48 +868,55 @@ Proof. exact: RseqmxC_ulsubseqmx. Qed.
        (rn2 : nat_R n21 n22) :
   refines (RseqmxC (addn_R rm1 rm2) (addn_R rn1 rn2) ==> RseqmxC rm1 rn2)
           (@matrix.ursubmx R m11 m21 n11 n21) (@ursubseqmx C m12 m22 n12 n22).
-Proof. param_comp ursubseqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp ursubseqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_ursubseqmx m1 m2 n1 n2 :
   refines (RseqmxC (addn_R (nat_Rxx m1) (nat_Rxx m2))
                    (addn_R (nat_Rxx n1) (nat_Rxx n2)) ==>
                    RseqmxC (nat_Rxx m1) (nat_Rxx n2))
           (@matrix.ursubmx R m1 m2 n1 n2) (@ursubseqmx C m1 m2 n1 n2).
-Proof. exact: RseqmxC_ursubseqmx. Qed.
+Proof. exact: RseqmxC_ursubseqmx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance RseqmxC_dlsubseqmx m11 m12 (rm1 : nat_R m11 m12) m21 m22
        (rm2 : nat_R m21 m22) n11 n12 (rn1 : nat_R n11 n12) n21 n22
        (rn2 : nat_R n21 n22) :
   refines (RseqmxC (addn_R rm1 rm2) (addn_R rn1 rn2) ==> RseqmxC rm2 rn1)
           (@matrix.dlsubmx R m11 m21 n11 n21) (@dlsubseqmx C m12 m22 n12 n22).
-Proof. param_comp dlsubseqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp dlsubseqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_dlsubseqmx m1 m2 n1 n2 :
   refines (RseqmxC (addn_R (nat_Rxx m1) (nat_Rxx m2))
                    (addn_R (nat_Rxx n1) (nat_Rxx n2)) ==>
                    RseqmxC (nat_Rxx m2) (nat_Rxx n1))
           (@matrix.dlsubmx R m1 m2 n1 n2) (@dlsubseqmx C m1 m2 n1 n2).
-Proof. exact: RseqmxC_dlsubseqmx. Qed.
+Proof. exact: RseqmxC_dlsubseqmx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance RseqmxC_drsubseqmx m11 m12 (rm1 : nat_R m11 m12) m21 m22
        (rm2 : nat_R m21 m22) n11 n12 (rn1 : nat_R n11 n12) n21 n22
        (rn2 : nat_R n21 n22) :
   refines (RseqmxC (addn_R rm1 rm2) (addn_R rn1 rn2) ==> RseqmxC rm2 rn2)
           (@matrix.drsubmx R m11 m21 n11 n21) (@drsubseqmx C m12 m22 n12 n22).
-Proof. param_comp drsubseqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp drsubseqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_drsubseqmx m1 m2 n1 n2 :
   refines (RseqmxC (addn_R (nat_Rxx m1) (nat_Rxx m2))
                    (addn_R (nat_Rxx n1) (nat_Rxx n2)) ==>
                    RseqmxC (nat_Rxx m2) (nat_Rxx n2))
           (@matrix.drsubmx R m1 m2 n1 n2) (@drsubseqmx C m1 m2 n1 n2).
-Proof. exact: RseqmxC_drsubseqmx. Qed.
+Proof. exact: RseqmxC_drsubseqmx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance RseqmxC_row_seqmx m1 m2 (rm : nat_R m1 m2) n11 n12
        (rn1 : nat_R n11 n12) n21 n22 (rn2 : nat_R n21 n22) :
   refines (RseqmxC rm rn1 ==> RseqmxC rm rn2 ==> RseqmxC rm (addn_R rn1 rn2))
           (@matrix.row_mx R m1 n11 n21) (@row_seqmx C m2 n12 n22).
-Proof. param_comp row_seqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp row_seqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_row_seqmx m n1 n2 :
   refines (RseqmxC (nat_Rxx m) (nat_Rxx n1) ==> RseqmxC (nat_Rxx m) (nat_Rxx n2)
@@ -847,7 +928,8 @@ Proof. exact: RseqmxC_row_seqmx. Qed.
        (rm2 : nat_R m21 m22) n1 n2 (rn : nat_R n1 n2) :
   refines (RseqmxC rm1 rn ==> RseqmxC rm2 rn ==> RseqmxC (addn_R rm1 rm2) rn)
           (@matrix.col_mx R m11 m21 n1) (@col_seqmx C m12 m22 n2).
-Proof. param_comp col_seqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp col_seqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_col_seqmx m1 m2 n :
   refines (RseqmxC (nat_Rxx m1) (nat_Rxx n) ==> RseqmxC (nat_Rxx m2) (nat_Rxx n)
@@ -861,7 +943,8 @@ Proof. exact: RseqmxC_col_seqmx. Qed.
   refines (RseqmxC rm1 rn1 ==> RseqmxC rm1 rn2 ==> RseqmxC rm2 rn1 ==>
            RseqmxC rm2 rn2 ==> RseqmxC (addn_R rm1 rm2) (addn_R rn1 rn2))
     (@matrix.block_mx R m11 m21 n11 n21) (@block_seqmx C m12 m22 n12 n22).
-Proof. param_comp block_seqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp block_seqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_block_seqmx m1 m2 n1 n2 :
   refines (RseqmxC (nat_Rxx m1) (nat_Rxx n1) ==>
@@ -875,7 +958,8 @@ Proof. exact: RseqmxC_block_seqmx. Qed.
 
 #[export] Instance RseqmxC_tr m1 m2 (rm : nat_R m1 m2) n1 n2 (rn : nat_R n1 n2) :
   refines (RseqmxC rm rn ==> RseqmxC rn rm) trmx (@trseqmx C m2 n2).
-Proof. param_comp trseqmx_R. Qed.
+Proof. param_comp trseqmx_R.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_trseqmx m n :
   refines (RseqmxC (nat_Rxx m) (nat_Rxx n) ==> RseqmxC (nat_Rxx n) (nat_Rxx m))
@@ -904,7 +988,7 @@ Local Instance implem_ord_ring : forall n, (implem_of 'I_n 'I_n) :=
 Local Open Scope rel_scope.
 
 Instance Rseqmx_diag_seqmx m1 m2 (rm : nat_R m1 m2) :
-  refines (Rseqmx (nat_R_S_R nat_R_O_R) rm ==> Rseqmx rm rm)
+  refines (Rseqmx (S_R O_R) rm ==> Rseqmx rm rm)
           diag_mx (diag_seqmx (A:=R)).
 Proof.
   rewrite refinesE=> _ _ [M sM h1 h2 h3].
@@ -1089,7 +1173,7 @@ Proof.
   apply refinesP; eapply refines_apply.
     apply Rseqmx_drsubseqmx.
   rewrite refinesE.
-  have H : nat_R_S_R rn = addn_R (nat_R_S_R nat_R_O_R) rn by [].
+  have H : S_R rn = addn_R (S_R O_R) rn by [].
   rewrite H in rM.
   eassumption.
 Qed.
@@ -1147,12 +1231,12 @@ Context `{forall n1 n2 (rn : nat_R n1 n2),
 Notation RseqmxC := (RseqmxC rAC).
 
 #[export] Instance RseqmxC_diag_seqmx m1 m2 (rm : nat_R m1 m2) :
-  refines (RseqmxC (nat_R_S_R nat_R_O_R) rm ==> RseqmxC rm rm)
+  refines (RseqmxC (S_R O_R) rm ==> RseqmxC rm rm)
           diag_mx (diag_seqmx (A:=C)).
 Proof. param_comp diag_seqmx_R. Qed.
 
 #[export] Instance refine_diag_seqmx m :
-  refines (RseqmxC (nat_R_S_R nat_R_O_R) (nat_Rxx m) ==>
+  refines (RseqmxC (S_R O_R) (nat_Rxx m) ==>
            RseqmxC (nat_Rxx m) (nat_Rxx m))
           diag_mx (diag_seqmx (A:=C)).
 Proof. exact: RseqmxC_diag_seqmx. Qed.
@@ -1206,7 +1290,8 @@ Proof. exact: RseqmxC_sub. Qed.
        p1 p2 (rp : nat_R p1 p2) :
   refines (RseqmxC rm rn ==> RseqmxC rn rp ==> RseqmxC rm rp)
           mulmx (@hmul_op _ _ _  m2 n2 p2).
-Proof. param_comp mul_seqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp mul_seqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_mul_seqmx m n p :
   refines (RseqmxC (nat_Rxx m) (nat_Rxx n) ==> RseqmxC (nat_Rxx n) (nat_Rxx p)
@@ -1241,7 +1326,7 @@ Proof.
   eapply refines_trans; tc.
     eapply Rseqmx_delta_seqmx; eassumption.
   rewrite refinesE; eapply delta_seqmx_R; try exact: refinesP; apply nat_Rxx.
-Qed.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_delta_seqmx m n i j :
   refines (RseqmxC (nat_Rxx m) (nat_Rxx n))
@@ -1250,7 +1335,8 @@ Proof. apply RseqmxC_delta_seqmx; exact: nat_Rxx. Qed.
 
 #[export] Instance RseqmxC_trace_seqmx m1 m2 (rm : nat_R m1 m2) :
   refines (RseqmxC rm rm ==> rAC) mxtrace (trace_seqmx (A:=C) (m:=m2)).
-Proof. param_comp trace_seqmx_R; rewrite refinesE; apply nat_Rxx. Qed.
+Proof. param_comp trace_seqmx_R; rewrite refinesE; apply nat_Rxx.
+Unshelve. all: exact: nat_Rxx. Qed.
 
 #[export] Instance refine_trace_seqmx m :
   refines (RseqmxC (nat_Rxx m) (nat_Rxx m) ==> rAC)
@@ -1417,7 +1503,7 @@ by coqeal.
 Abort.
 
 Goal (pid_mx 4 * copid_mx 4 == 0 :> 'M[{poly {poly int}}]_(5)).
-(* by coqeal. *)
+by coqeal.
 Abort.
 
 Definition Maddm : 'M[int]_(2) := \matrix_(i, j < 2) (i + j * i)%:Z.
@@ -1462,11 +1548,11 @@ Definition Mp : 'M[{poly {poly int}}]_(2,2) :=
   \matrix_(i,j < 2) (Poly [:: Poly [:: 3%:Z; 0; 1]; 0]).
 
 Goal (Mp + -Mp == 0).
-(* by coqeal. *)
+by coqeal.
 Abort.
 
 Goal (Mp *m 0 == 0 :> 'M[_]_(2,2)).
-(* by coqeal. *)
+by coqeal.
 Abort.
 
 Definition M := \matrix_(i,j < 2) 1%:Z.

--- a/refinements/seqmx_complements.v
+++ b/refinements/seqmx_complements.v
@@ -19,7 +19,7 @@ Arguments refines A%type B%type R%rel _ _. (* Fix a scope issue with refines *)
 
 Arguments refinesP {T T' R x y} _.
 
-#[export] Hint Resolve list_R_nil_R : core.
+#[export] Hint Resolve nil_R : core.
 
 Notation ord_instN := (fun _ : nat => nat) (only parsing).
 
@@ -120,7 +120,7 @@ by rewrite /fun_of_seqmx.
 Qed.
 
 #[export] Instance Rseqmx_row_seqmx m1 m2 (rm : nat_R m1 m2) n1 n2 (rn : nat_R n1 n2) :
-  refines (Rord rm ==> Rseqmx rm rn ==> Rseqmx (nat_R_S_R nat_R_O_R) rn)
+  refines (Rord rm ==> Rseqmx rm rn ==> Rseqmx (S_R O_R) rn)
     (@row A m1 n1) (@row_seqmx A m2 n2).
 Proof.
 rewrite refinesE=> i _ <- _ _ [M sM h1 h2 h3].
@@ -225,11 +225,18 @@ Qed.
 
 (** ** Parametricity *)
 
-Parametricity fun_of_seqmx.
-Parametricity row_seqmx.
-Parametricity store_seqmx.
-Parametricity trmx_seqmx.
-Parametricity heq_seqmx.
+Elpi derive.param2 fun_of_of.
+Elpi derive.param2 fun_of_seqmx.
+Elpi derive.param2 row_of.
+Elpi derive.param2 row_seqmx.
+Elpi derive.param2 store_of.
+Elpi derive.param2 store_aux.
+Elpi derive.param2 store_seqmx0.
+Elpi derive.param2 store_seqmx.
+Elpi derive.param2 trmx_of.
+Elpi derive.param2 trmx_seqmx.
+Elpi derive.param2 heq_of.
+Elpi derive.param2 heq_seqmx.
 
 Section seqmx_param.
 

--- a/refinements/seqpoly.v
+++ b/refinements/seqpoly.v
@@ -1,3 +1,4 @@
+From elpi Require Import derive.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat div seq ssralg.
 From mathcomp Require Import path choice fintype tuple finset bigop poly polydiv.
 
@@ -77,22 +78,31 @@ Proof. by elim: s. Qed.
 
 End seqpoly_op.
 
-Parametricity cast_seqpoly.
-Parametricity seqpoly0.
-Parametricity seqpoly1.
-Parametricity opp_seqpoly.
-Parametricity add_seqpoly.
-Parametricity sub_seqpoly.
-Parametricity scale_seqpoly.
-Parametricity mul_seqpoly.
+Elpi derive.param2 seqpoly.
+Elpi derive.param2 cast_seqpoly.
+Elpi derive.param2 seqpoly0.
+Elpi derive.param2 seqpoly1.
+Elpi derive.param2 List.map.
+Elpi derive.param2 opp_seqpoly.
+Elpi derive.param2 add_seqpoly_fun.
+Elpi derive.param2 add_seqpoly.
+Elpi derive.param2 sub_seqpoly.
+Elpi derive.param2 scale_seqpoly.
+Elpi derive.param2 mul_seqpoly.
 Definition exp_seqpoly' := Eval compute in exp_seqpoly.
-Parametricity exp_seqpoly'.
-Realizer exp_seqpoly as exp_seqpoly_R := exp_seqpoly'_R.
-Parametricity size_seqpoly.
-Parametricity eq_seqpoly.
-Parametricity shift_seqpoly.
-Parametricity split_seqpoly.
-Parametricity lead_coef_seqpoly.
+Elpi derive.param2 exp_seqpoly'.
+Definition exp_seqpoly_R := exp_seqpoly'_R.
+Elpi Accumulate derive Db derive.param2.db.
+Elpi Accumulate derive.param2.db "
+:before ""param:fail""
+param {{ @exp_seqpoly }} {{ @exp_seqpoly }} {{ @exp_seqpoly_R }}.
+".
+Elpi derive.param2 size_seqpoly.
+Elpi derive.param2 eq_seqpoly.
+Elpi derive.param2 shift_seqpoly.
+Elpi derive.param2 split_seqpoly.
+Elpi derive.param2 predn.
+Elpi derive.param2 lead_coef_seqpoly.
 
 Section seqpoly_more_op.
 
@@ -464,7 +474,7 @@ Definition RseqpolyC : {poly R} -> seq C -> Type :=
 
 #[export] Instance RseqpolyC_cons :
   refines (rAC ==> RseqpolyC ==> RseqpolyC) (@cons_poly R) cons.
-Proof. param_comp list_R_cons_R. Qed.
+Proof. param_comp cons_R. Qed.
 
 #[export] Instance RseqpolyC_cast :
   refines (rAC ==> RseqpolyC) polyC cast_op.
@@ -500,7 +510,7 @@ Proof. param_comp mul_seqpoly_R. Qed.
 Proof.
   eapply refines_trans; tc.
   rewrite refinesE; do ?move=> ?*.
-  eapply (exp_seqpoly_R (N_R:=rN))=> // *;
+  eapply (@exp_seqpoly_R _ _ _ _ _ rN)=> // *;
     exact: refinesP.
 Qed.
 
@@ -519,7 +529,7 @@ Proof.
   relation, why? *)
   eapply refines_trans; tc.
   rewrite refinesE; do ?move=> ?*.
-  eapply (shift_seqpoly_R (N_R:=rN))=> // *;
+  eapply (@shift_seqpoly_R _ _ _ _ _ rN)=> // *;
     exact: refinesP.
 Qed.
 
@@ -571,7 +581,7 @@ Proof.
 have: refines (rN ==> list_R rAC ==> prod_R (list_R rAC) (list_R rAC))
     split_op split_op.
   rewrite refinesE; do ?move=> ?*.
-  eapply (split_seqpoly_R (N_R:=rN))=> // *.
+  eapply (@split_seqpoly_R _ _ _ _ _ rN)=> // *.
   exact: refinesP.
 exact: refines_trans Rseqpoly_split.
 Qed.

--- a/refinements/trivial_seq.v
+++ b/refinements/trivial_seq.v
@@ -1,3 +1,5 @@
+From elpi Require Import derive.
+
 Require Import ZArith.
 
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat div seq zmodp.
@@ -15,7 +17,7 @@ Context (A : Type) (N : Type) `{zero_of N} `{one_of N} `{add_of N}.
   fix size xs := if xs is x :: s then (size s + 1)%C else 0%C.
 
 End size_seq.
-Parametricity size_seq.
+Elpi derive.param2 size_seq.
 
 Lemma size_seqE T (s : seq T) : (@size_seq _ _ 0%N 1%N addn) s = size s.
 Proof. by elim: s => //= x s ->; rewrite [(_ + _)%C]addn1. Qed.
@@ -47,7 +49,7 @@ Qed.
           (nth [::]) (fun s (n : N) => nth [::] s (spec n)).
 Proof.
   param nth_R.
-    rewrite refinesE; exact: list_R_nil_R.
+    rewrite refinesE; exact: nil_R.
   rewrite -[X in refines _ X _]/(spec_id _); exact: refines_apply.
 Qed.
 
@@ -56,11 +58,11 @@ Qed.
 Proof.
   rewrite refinesE.
   elim: s=> [|a s ihs] /=.
-    exact: list_R_nil_R.
-  apply: list_R_cons_R.
+    exact: nil_R.
+  apply: cons_R.
     elim: a=> [|hd tl ih] /=.
-      exact: list_R_nil_R.
-      apply: list_R_cons_R.
+      exact: nil_R.
+      apply: cons_R.
       have heq : refines eq hd hd by rewrite refinesE.
       rewrite -[X in rAC X _]/(implem_id _).
       exact: refinesP.


### PR DESCRIPTION
Should finally enable to compile CoqEAL again on Coq master / Rocq 9.0.

#### Overlay (to be merged in sync with the current PR)

- https://github.com/coq-community/apery/pull/30